### PR TITLE
[Enhancement] Support column names longer than 64, up to 1024 bytes

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/FeNameFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/FeNameFormat.java
@@ -38,7 +38,7 @@ public class FeNameFormat {
     // Now we can not accept all characters because current design of delete save delete cond contains column name,
     // so it can not distinguish whether it is an operator or a column name
     // the future new design will improve this problem and open this limitation
-    private static final String COLUMN_NAME_REGEX = "^[^\0=<>!\\*]{1,64}$";
+    private static final String COLUMN_NAME_REGEX = "^[^\0=<>!\\*]{1,1023}$";
 
     // The user name  by kerberos authentication may include the host name, so additional adaptation is required.
     private static final String MYSQL_USER_NAME_REGEX = "^[a-zA-Z]\\w{1,63}/?[.\\w-]{0,63}$";


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
Starrocks supports column names longer than 64 bytes, up to 1024 bytes

## Problem Summary(Required) ：
StarRocks used to support column name with length up to 64 bytes. We have many columns longer than 64 bytes. Extend it to be 1024 bytes.
