### PR TITLE
Resource Isolation Feature Checkpoint 2: Selection of compute node considering resource isolation group

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -42,7 +42,7 @@ under the License.
         <paimon.version>0.8.2</paimon.version>
         <delta-kernel.version>4.0.0rc1</delta-kernel.version>
         <staros.version>3.3-rc3</staros.version>
-        <python>python</python>
+        <python>python3</python>
     </properties>
 
     <profiles>

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
@@ -423,7 +423,7 @@ public class TableFunctionTable extends Table {
         TNetworkAddress address;
         List<Long> nodeIds = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendIds(true);
         if (RunMode.isSharedDataMode()) {
-            nodeIds.addAll(GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getComputeNodeIds(true));
+            nodeIds.addAll(GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getAvailableComputeNodeIds());
         }
         if (nodeIds.isEmpty()) {
             if (RunMode.isSharedNothingMode()) {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProvider.java
@@ -245,7 +245,7 @@ public class DefaultSharedDataWorkerProvider implements WorkerProvider {
                     LOG.warn(String.format("The internal tablet mapper doesn't seem to know about the resource" +
                                     " isolation group %s. Its state is %s.",
                             GlobalStateMgr.getCurrentState().getNodeMgr().getMySelf().getResourceIsolationGroup(),
-                            mapper.DebugString()));
+                            mapper.debugString()));
                     return -1;
                 }
                 for (Long possibleBackup : cnIdsOrderedByPreference) {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProvider.java
@@ -249,13 +249,13 @@ public class DefaultSharedDataWorkerProvider implements WorkerProvider {
                     return -1;
                 }
                 for (Long possibleBackup : cnIdsOrderedByPreference) {
-                    if (possibleBackup != workerId && availableID2ComputeNode.containsKey(possibleBackup) &&
-                            !SimpleScheduler.isInBlocklist(possibleBackup)) {
+                    if (possibleBackup != workerId && availableID2ComputeNode.containsKey(possibleBackup)) {
                         return possibleBackup;
                     }
                 }
                 LOG.warn(String.format("Tried to use internal tablet to CN mapper but it failed to find an available" +
                         " cn for the given tablet %d", tabletId.get()));
+                return -1;
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ColocatedBackendSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ColocatedBackendSelector.java
@@ -37,9 +37,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Function;
+
+import static com.starrocks.qe.scheduler.Utils.maybeGetTabletId;
 
 public class ColocatedBackendSelector implements BackendSelector {
     private static final Logger LOG = LogManager.getLogger(ColocatedBackendSelector.class);
@@ -120,10 +123,11 @@ public class ColocatedBackendSelector implements BackendSelector {
         int minBucketNum = Integer.MAX_VALUE;
         long minBackendId = Long.MAX_VALUE;
         List<TScanRangeLocation> backupLocations = new ArrayList<>();
+        Optional<Long> optTabletId = maybeGetTabletId(seqLocation.scan_range);
         for (TScanRangeLocation location : seqLocation.locations) {
             if (!workerProvider.isDataNodeAvailable(location.getBackend_id())) {
                 if (workerProvider.allowUsingBackupNode()) {
-                    long backupNodeId = workerProvider.selectBackupWorker(location.getBackend_id());
+                    long backupNodeId = workerProvider.selectBackupWorker(location.getBackend_id(), optTabletId);
                     LOG.debug("Select a backup node:{} for node:{}", backupNodeId, location.getBackend_id());
                     if (backupNodeId > 0) {
                         // using the backupNode to generate a new ScanRangeLocation

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ColocatedBackendSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ColocatedBackendSelector.java
@@ -42,7 +42,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Function;
 
-import static com.starrocks.qe.scheduler.Utils.maybeGetTabletId;
+import static com.starrocks.qe.scheduler.Utils.getOptionalTabletId;
 
 public class ColocatedBackendSelector implements BackendSelector {
     private static final Logger LOG = LogManager.getLogger(ColocatedBackendSelector.class);
@@ -123,7 +123,7 @@ public class ColocatedBackendSelector implements BackendSelector {
         int minBucketNum = Integer.MAX_VALUE;
         long minBackendId = Long.MAX_VALUE;
         List<TScanRangeLocation> backupLocations = new ArrayList<>();
-        Optional<Long> optTabletId = maybeGetTabletId(seqLocation.scan_range);
+        Optional<Long> optTabletId = getOptionalTabletId(seqLocation.scan_range);
         for (TScanRangeLocation location : seqLocation.locations) {
             if (!workerProvider.isDataNodeAvailable(location.getBackend_id())) {
                 if (workerProvider.allowUsingBackupNode()) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/NormalBackendSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/NormalBackendSelector.java
@@ -32,7 +32,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 
-import static com.starrocks.qe.scheduler.Utils.maybeGetTabletId;
+import static com.starrocks.qe.scheduler.Utils.getOptionalTabletId;
 
 public class NormalBackendSelector implements BackendSelector {
     private static final Logger LOG = LogManager.getLogger(NormalBackendSelector.class);
@@ -75,7 +75,7 @@ public class NormalBackendSelector implements BackendSelector {
         }
 
         for (TScanRangeLocations scanRangeLocations : locations) {
-            Optional<Long> optTabletId = maybeGetTabletId(scanRangeLocations.scan_range);
+            Optional<Long> optTabletId = getOptionalTabletId(scanRangeLocations.scan_range);
             // assign this scan range to the host w/ the fewest assigned row count
             Long minRowCount = Long.MAX_VALUE;
             TScanRangeLocation minLocation = null;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
@@ -39,6 +39,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntSupplier;
@@ -271,7 +272,7 @@ public class DefaultWorkerProvider implements WorkerProvider {
     }
 
     @Override
-    public long selectBackupWorker(long workerId) {
+    public long selectBackupWorker(long workerId, Optional<Long> tabletId) {
         // not allowed to have backup node
         return -1;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Utils.java
@@ -1,0 +1,15 @@
+package com.starrocks.qe.scheduler;
+
+import com.starrocks.thrift.TScanRange;
+
+import java.util.Optional;
+
+public class Utils {
+    public static Optional<Long> maybeGetTabletId(TScanRange scanRange) {
+        Optional<Long> optTabletId = Optional.empty();
+        if (scanRange.internal_scan_range != null) {
+            optTabletId = Optional.of(scanRange.internal_scan_range.tablet_id);
+        }
+        return optTabletId;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Utils.java
@@ -18,7 +18,8 @@ import com.starrocks.thrift.TScanRange;
 import java.util.Optional;
 
 public class Utils {
-    public static Optional<Long> maybeGetTabletId(TScanRange scanRange) {
+    // We can only get the tablet id for an internal scan.
+    public static Optional<Long> getOptionalTabletId(TScanRange scanRange) {
         Optional<Long> optTabletId = Optional.empty();
         if (scanRange.internal_scan_range != null) {
             optTabletId = Optional.of(scanRange.internal_scan_range.tablet_id);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Utils.java
@@ -1,3 +1,16 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package com.starrocks.qe.scheduler;
 
 import com.starrocks.thrift.TScanRange;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/WorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/WorkerProvider.java
@@ -20,6 +20,7 @@ import com.starrocks.system.SystemInfoService;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * WorkerProvider provides available workers to a job scheduler, and records the selected workers.
@@ -100,5 +101,5 @@ public interface WorkerProvider {
      *
      * @return -1, no available backup worker
      */
-    long selectBackupWorker(long workerId);
+    long selectBackupWorker(long workerId, Optional<Long> tabletId);
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/WarehouseManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/WarehouseManager.java
@@ -131,8 +131,7 @@ public class WarehouseManager implements Writable {
     private List<Long> getAllComputeNodeIds(long warehouseId, long workerGroupId) {
         // If we're using resource isolation groups, we bypass the call to StarOS/StarMgr
         SystemInfoService systemInfoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
-        if (systemInfoService.usingResourceIsolationGroups()) {
-
+        if (systemInfoService.shouldUseInternalTabletToCnMapper()) {
             if (warehouseId != DEFAULT_WAREHOUSE_ID || workerGroupId != StarOSAgent.DEFAULT_WORKER_GROUP_ID) {
                 // Note that workerGroupId is not the same as resourceIsolationGroupId
                 throw new IllegalArgumentException(String.format("Cannot use resource groups with non-default" +
@@ -202,12 +201,12 @@ public class WarehouseManager implements Writable {
     public Set<Long> getAllComputeNodeIdsAssignToTablet(Long warehouseId, LakeTablet tablet) {
         // If we're using resource isolation groups, we bypass the call to StarOS/StarMgr
         SystemInfoService systemInfoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
-        if (systemInfoService.usingResourceIsolationGroups()) {
+        if (systemInfoService.shouldUseInternalTabletToCnMapper()) {
             if (warehouseId != DEFAULT_WAREHOUSE_ID) {
                 throw new IllegalArgumentException(String.format("Cannot use resource groups with non-default" +
                         " warehouse %d", warehouseId));
             }
-            List<Long> computeNodeIds = systemInfoService.internalTabletMapper().computeNodesForTablet(tablet);
+            List<Long> computeNodeIds = systemInfoService.internalTabletMapper().computeNodesForTablet(tablet.getId());
             if (computeNodeIds == null) {
                 return null;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -47,6 +47,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
+import static com.starrocks.system.ResourceIsolationGroupUtils.DEFAULT_RESOURCE_ISOLATION_GROUP_ID;
+
 /**
  * This class extends the primary identifier of a compute node with computing capabilities
  * and no storage capacity。
@@ -265,7 +267,7 @@ public class ComputeNode implements IComputable, Writable {
     }
 
     public String getResourceIsolationGroup() {
-        return resourceIsolationGroup;
+        return java.util.Objects.requireNonNullElse(resourceIsolationGroup, DEFAULT_RESOURCE_ISOLATION_GROUP_ID);
     }
     public void setResourceIsolationGroup(String group) {
         this.resourceIsolationGroup = group;

--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -48,6 +48,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static com.starrocks.system.ResourceIsolationGroupUtils.DEFAULT_RESOURCE_ISOLATION_GROUP_ID;
+import static java.util.Objects.requireNonNullElse;
 
 /**
  * This class extends the primary identifier of a compute node with computing capabilities
@@ -267,7 +268,7 @@ public class ComputeNode implements IComputable, Writable {
     }
 
     public String getResourceIsolationGroup() {
-        return java.util.Objects.requireNonNullElse(resourceIsolationGroup, DEFAULT_RESOURCE_ISOLATION_GROUP_ID);
+        return requireNonNullElse(resourceIsolationGroup, DEFAULT_RESOURCE_ISOLATION_GROUP_ID);
     }
     public void setResourceIsolationGroup(String group) {
         this.resourceIsolationGroup = group;

--- a/fe/fe-core/src/main/java/com/starrocks/system/Frontend.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/Frontend.java
@@ -47,6 +47,9 @@ import com.starrocks.system.HeartbeatResponse.HbStatus;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.Objects;
+
+import static com.starrocks.system.ResourceIsolationGroupUtils.DEFAULT_RESOURCE_ISOLATION_GROUP_ID;
 
 public class Frontend implements Writable {
     @SerializedName(value = "r")
@@ -133,7 +136,7 @@ public class Frontend implements Writable {
     }
 
     public String getResourceIsolationGroup() {
-        return resourceIsolationGroup;
+        return Objects.requireNonNullElse(resourceIsolationGroup, DEFAULT_RESOURCE_ISOLATION_GROUP_ID);
     }
     public void setResourceIsolationGroup(String group) {
         this.resourceIsolationGroup = group;

--- a/fe/fe-core/src/main/java/com/starrocks/system/ResourceIsolationGroupUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ResourceIsolationGroupUtils.java
@@ -1,0 +1,50 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.system;
+
+import java.util.Objects;
+
+public class ResourceIsolationGroupUtils {
+    public static final String DEFAULT_RESOURCE_ISOLATION_GROUP_ID = "";
+
+    public static boolean resourceIsolationGroupMatches(String rig1, String rig2) {
+        if (Objects.equals(rig1, rig2)) {
+            return true;
+        }
+        boolean unset1 = rig1 == null || rig1.isEmpty();
+        boolean unset2 = rig2 == null || rig2.isEmpty();
+        return unset1 && unset2;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/system/ResourceIsolationGroupUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ResourceIsolationGroupUtils.java
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -132,7 +132,9 @@ public class SystemInfoService implements GsonPostProcessable {
         tabletComputeNodeMapper = new TabletComputeNodeMapper();
     }
 
-    public boolean usingResourceIsolationGroups() {
+    public boolean shouldUseInternalTabletToCnMapper() {
+        // We prefer to use the TabletComputeNodeMapper rather than delegating to StarOS/StarMgr for tablet->CN mappings
+        // if and only if we're using resource isolation groups.
         return tabletComputeNodeMapper.numResourceIsolationGroups() > 1;
     }
     public TabletComputeNodeMapper internalTabletMapper() {

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -100,6 +100,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.starrocks.common.util.PropertyAnalyzer.getResourceIsolationGroupFromProperties;
+import static com.starrocks.system.ResourceIsolationGroupUtils.DEFAULT_RESOURCE_ISOLATION_GROUP_ID;
+import static com.starrocks.system.ResourceIsolationGroupUtils.resourceIsolationGroupMatches;
 
 public class SystemInfoService implements GsonPostProcessable {
     private static final Logger LOG = LogManager.getLogger(SystemInfoService.class);
@@ -115,6 +117,9 @@ public class SystemInfoService implements GsonPostProcessable {
     private volatile ImmutableMap<Long, DiskInfo> pathHashToDishInfoRef;
 
     private final NodeSelector nodeSelector;
+    // The TabletComputeNodeMapper must be updated any time a compute node is added, removed,
+    // or has its resource isolation group modified.
+    private final TabletComputeNodeMapper tabletComputeNodeMapper;
 
     public SystemInfoService() {
         idToBackendRef = new ConcurrentHashMap<>();
@@ -124,6 +129,14 @@ public class SystemInfoService implements GsonPostProcessable {
         pathHashToDishInfoRef = ImmutableMap.of();
 
         nodeSelector = new NodeSelector(this);
+        tabletComputeNodeMapper = new TabletComputeNodeMapper();
+    }
+
+    public boolean usingResourceIsolationGroups() {
+        return tabletComputeNodeMapper.numResourceIsolationGroups() > 1;
+    }
+    public TabletComputeNodeMapper internalTabletMapper() {
+        return tabletComputeNodeMapper;
     }
 
     public void addComputeNodes(List<Pair<String, Integer>> hostPortPairs)
@@ -156,6 +169,8 @@ public class SystemInfoService implements GsonPostProcessable {
      */
     public void addComputeNode(ComputeNode computeNode) {
         idToComputeNodeRef.put(computeNode.getId(), computeNode);
+        tabletComputeNodeMapper.addComputeNode(computeNode.getId(),
+                DEFAULT_RESOURCE_ISOLATION_GROUP_ID);
     }
 
     /**
@@ -163,6 +178,8 @@ public class SystemInfoService implements GsonPostProcessable {
      */
     public void dropComputeNode(ComputeNode computeNode) {
         idToComputeNodeRef.remove(computeNode.getId());
+        tabletComputeNodeMapper.removeComputeNode(computeNode.getId(),
+                DEFAULT_RESOURCE_ISOLATION_GROUP_ID);
     }
 
     // Final entry of adding compute node
@@ -174,6 +191,8 @@ public class SystemInfoService implements GsonPostProcessable {
         newComputeNode.setWorkerGroupId(StarOSAgent.DEFAULT_WORKER_GROUP_ID);
         newComputeNode.setWarehouseId(WarehouseManager.DEFAULT_WAREHOUSE_ID);
 
+        tabletComputeNodeMapper.addComputeNode(newComputeNode.getId(),
+                DEFAULT_RESOURCE_ISOLATION_GROUP_ID);
         // log
         GlobalStateMgr.getCurrentState().getEditLog().logAddComputeNode(newComputeNode);
         LOG.info("finished to add {} ", newComputeNode);
@@ -313,14 +332,17 @@ public class SystemInfoService implements GsonPostProcessable {
         // update backend based on properties
         for (Map.Entry<String, String> entry : properties.entrySet()) {
             if (entry.getKey().equals(AlterSystemStmtAnalyzer.PROP_KEY_GROUP)) {
-                // "" means clean group label
-                if (entry.getValue().isEmpty()) {
-                    computeNode.setResourceIsolationGroup("");
-                    continue;
-                }
                 String oldResourceIsolationGroup = computeNode.getResourceIsolationGroup();
-                String newResourceIsolationGroup = getResourceIsolationGroupFromProperties(properties);
+                String newResourceIsolationGroup = DEFAULT_RESOURCE_ISOLATION_GROUP_ID;
+                // "" value in the properties means use default group label
+                if (!entry.getValue().isEmpty()) {
+                    newResourceIsolationGroup = getResourceIsolationGroupFromProperties(properties);
+                }
+                // Step 1: update in-memory representation of compute node
                 computeNode.setResourceIsolationGroup(newResourceIsolationGroup);
+                // Step 2: update internal table mapper to reflect the new membership of compute node
+                tabletComputeNodeMapper.modifyComputeNode(computeNode.getId(),
+                        oldResourceIsolationGroup, newResourceIsolationGroup);
                 String opMessage = String.format("%s:%d's group has been modified from %s to %s",
                         computeNode.getHost(), computeNode.getHeartbeatPort(),
                         oldResourceIsolationGroup, newResourceIsolationGroup);
@@ -427,6 +449,9 @@ public class SystemInfoService implements GsonPostProcessable {
                 GlobalStateMgr.getCurrentState().getStarOSAgent().removeWorker(workerAddr, dropComputeNode.getWorkerGroupId());
             }
         }
+
+        // drop from internal tablet mapper
+        tabletComputeNodeMapper.removeComputeNode(dropComputeNode.getId(), dropComputeNode.getResourceIsolationGroup());
 
         // log
         GlobalStateMgr.getCurrentState().getEditLog()
@@ -678,6 +703,7 @@ public class SystemInfoService implements GsonPostProcessable {
     public void dropAllComputeNode() {
         // update idToComputeNodeRef
         idToComputeNodeRef.clear();
+        tabletComputeNodeMapper.clear();
     }
 
     public Backend getBackend(long backendId) {
@@ -940,12 +966,15 @@ public class SystemInfoService implements GsonPostProcessable {
     }
 
     public List<Long> getAvailableComputeNodeIds() {
+        String thisResourceIsolationGroup = GlobalStateMgr.getCurrentState().getNodeMgr().getMySelf().
+                getResourceIsolationGroup();
         List<Long> computeNodeIds = Lists.newArrayList(idToComputeNodeRef.keySet());
 
         Iterator<Long> iter = computeNodeIds.iterator();
         while (iter.hasNext()) {
             ComputeNode cn = this.getComputeNode(iter.next());
-            if (cn == null || !cn.isAvailable()) {
+            if (cn == null || !cn.isAvailable() ||
+                    !resourceIsolationGroupMatches(cn.getResourceIsolationGroup(), thisResourceIsolationGroup)) {
                 iter.remove();
             }
         }
@@ -967,8 +996,11 @@ public class SystemInfoService implements GsonPostProcessable {
     }
 
     public List<ComputeNode> getAvailableComputeNodes() {
+        String thisResourceIsolationGroup = GlobalStateMgr.getCurrentState().getNodeMgr().getMySelf().
+                getResourceIsolationGroup();
         return getComputeNodes().stream()
                 .filter(ComputeNode::isAvailable)
+                .filter(cn -> resourceIsolationGroupMatches(cn.getResourceIsolationGroup(), thisResourceIsolationGroup))
                 .collect(Collectors.toList());
     }
 
@@ -1071,6 +1103,7 @@ public class SystemInfoService implements GsonPostProcessable {
         // update idToComputeNode
         newComputeNode.setBackendState(BackendState.using);
         idToComputeNodeRef.put(newComputeNode.getId(), newComputeNode);
+        tabletComputeNodeMapper.addComputeNode(newComputeNode.getId(), DEFAULT_RESOURCE_ISOLATION_GROUP_ID);
     }
 
     public void replayAddBackend(Backend newBackend) {
@@ -1103,6 +1136,9 @@ public class SystemInfoService implements GsonPostProcessable {
             String workerAddr = NetUtils.getHostPortInAccessibleFormat(cn.getHost(), starletPort);
             GlobalStateMgr.getCurrentState().getStarOSAgent().removeWorkerFromMap(workerAddr);
         }
+
+        // remove from internal mapping from tablet to compute node
+        tabletComputeNodeMapper.removeComputeNode(cn.getId(), cn.getResourceIsolationGroup());
     }
 
     public void replayDropBackend(Backend backend) {
@@ -1176,6 +1212,8 @@ public class SystemInfoService implements GsonPostProcessable {
                     " [%s]", persistentState));
             return;
         }
+        tabletComputeNodeMapper.modifyComputeNode(id, inMemoryState.getResourceIsolationGroup(),
+                persistentState.getResourceIsolationGroup());
         updateCommonInMemoryState(persistentState, inMemoryState);
         // The difference between this function and updateInMemoryState is that we set group and not location nor disks
         inMemoryState.setResourceIsolationGroup(persistentState.getResourceIsolationGroup());

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -135,8 +135,9 @@ public class SystemInfoService implements GsonPostProcessable {
     public boolean shouldUseInternalTabletToCnMapper() {
         // We prefer to use the TabletComputeNodeMapper rather than delegating to StarOS/StarMgr for tablet->CN mappings
         // if and only if we're using resource isolation groups.
-        return tabletComputeNodeMapper.numResourceIsolationGroups() > 1;
+        return tabletComputeNodeMapper.trackingNonDefaultResourceIsolationGroup();
     }
+
     public TabletComputeNodeMapper internalTabletMapper() {
         return tabletComputeNodeMapper;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/system/TabletComputeNodeMapper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/TabletComputeNodeMapper.java
@@ -111,7 +111,7 @@ public class TabletComputeNodeMapper {
         return numGroups > 1 || !resourceIsolationGroupToTabletMapping.containsKey(DEFAULT_RESOURCE_ISOLATION_GROUP_ID);
     }
 
-    private String remapResourceIsolationGroupIfNull(String resourceIsolationGroup) {
+    private String getResourceIsolationGroupName(String resourceIsolationGroup) {
         return resourceIsolationGroup == null ? DEFAULT_RESOURCE_ISOLATION_GROUP_ID : resourceIsolationGroup;
     }
 
@@ -122,7 +122,7 @@ public class TabletComputeNodeMapper {
     }
 
     public void addComputeNode(Long computeNodeId, String resourceIsolationGroup) {
-        resourceIsolationGroup = remapResourceIsolationGroupIfNull(resourceIsolationGroup);
+        resourceIsolationGroup = getResourceIsolationGroupName(resourceIsolationGroup);
         writeLock.lock();
         try {
             addComputeNodeUnsynchronized(computeNodeId, resourceIsolationGroup);
@@ -145,7 +145,7 @@ public class TabletComputeNodeMapper {
 
     // This will succeed even if the resource isolation group is not being tracked.
     public void removeComputeNode(Long computeNodeId, String resourceIsolationGroup) {
-        resourceIsolationGroup = remapResourceIsolationGroupIfNull(resourceIsolationGroup);
+        resourceIsolationGroup = getResourceIsolationGroupName(resourceIsolationGroup);
         writeLock.lock();
         try {
             removeComputeNodeUnsynchronized(computeNodeId, resourceIsolationGroup);
@@ -167,8 +167,8 @@ public class TabletComputeNodeMapper {
 
     public void modifyComputeNode(Long computeNodeId,
                                   String oldResourceIsolationGroup, String newResourceIsolationGroup) {
-        oldResourceIsolationGroup = remapResourceIsolationGroupIfNull(oldResourceIsolationGroup);
-        newResourceIsolationGroup = remapResourceIsolationGroupIfNull(newResourceIsolationGroup);
+        oldResourceIsolationGroup = getResourceIsolationGroupName(oldResourceIsolationGroup);
+        newResourceIsolationGroup = getResourceIsolationGroupName(newResourceIsolationGroup);
         if (oldResourceIsolationGroup.equals(newResourceIsolationGroup)) {
             return;
         }
@@ -190,7 +190,7 @@ public class TabletComputeNodeMapper {
         try {
             String thisResourceIsolationGroup = GlobalStateMgr.getCurrentState().getNodeMgr().getMySelf().
                     getResourceIsolationGroup();
-            thisResourceIsolationGroup = remapResourceIsolationGroupIfNull(thisResourceIsolationGroup);
+            thisResourceIsolationGroup = getResourceIsolationGroupName(thisResourceIsolationGroup);
             if (!this.resourceIsolationGroupToTabletMapping.containsKey(thisResourceIsolationGroup)) {
                 return null;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/system/TabletComputeNodeMapper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/TabletComputeNodeMapper.java
@@ -115,7 +115,7 @@ public class TabletComputeNodeMapper {
         return resourceIsolationGroup == null ? DEFAULT_RESOURCE_ISOLATION_GROUP_ID : resourceIsolationGroup;
     }
 
-    public String DebugString() {
+    public String debugString() {
         return resourceIsolationGroupToTabletMapping.entrySet().stream()
                 .map(entry -> String.format("%-15s : %s", entry.getKey(), entry.getValue()))
                 .collect(Collectors.joining("\n"));

--- a/fe/fe-core/src/main/java/com/starrocks/system/TabletComputeNodeMapper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/TabletComputeNodeMapper.java
@@ -1,0 +1,205 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.system;
+
+import com.google.common.hash.Funnel;
+import com.google.common.hash.Hashing;
+import com.google.common.hash.PrimitiveSink;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.common.util.ConsistentHashRing;
+import com.starrocks.common.util.HashRing;
+import com.starrocks.lake.LakeTablet;
+import com.starrocks.server.GlobalStateMgr;
+import org.jetbrains.annotations.TestOnly;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import static com.starrocks.system.ResourceIsolationGroupUtils.DEFAULT_RESOURCE_ISOLATION_GROUP_ID;
+
+/**
+ * What:
+ * Maps tablet to compute node(s) which are responsible for operations there-on.
+ * Why:
+ * Flexible replacement for StarOS/StarMgr management of the same type of mapping.
+ * Useful for when the system is using resource-isolation groups, in that case each
+ * ComputeNode should belong to exactly one TabletComputeNodeMapper (not necessarily on the same Frontend).
+ * Notes on use:
+ * Updated whenever there's an addition or removal of a compute node to the resource-isolation-group.
+ * If using multiple replicas, consider the earlier-index CN for a given tablet to be more preferred
+ * If some CN is removed, and it was the primary CN for some tablet, the first backup CN will become the primary
+ * Thread-safe after initialization.
+ *
+ */
+
+public class TabletComputeNodeMapper {
+
+    private static final int CONSISTENT_HASH_RING_VIRTUAL_NUMBER = 256;
+    private static final Tablet ARBITRARY_FAKE_TABLET = new LakeTablet(1L);
+
+    private class TabletMap {
+        private final HashRing<Tablet, Long> tabletToComputeNodeId;
+        private int numReplicas;
+
+        TabletMap() {
+            tabletToComputeNodeId = new ConsistentHashRing<>(
+                    Hashing.murmur3_128(), new TabletFunnel(), new ComputeNodeIdFunnel(),
+                    Collections.emptyList(), CONSISTENT_HASH_RING_VIRTUAL_NUMBER);
+            numReplicas = 1;
+        }
+
+        private boolean tracksSomeComputeNode() {
+            return !tabletToComputeNodeId.get(ARBITRARY_FAKE_TABLET, 1).isEmpty();
+        }
+    }
+
+    private final Map<String, TabletMap> resourceIsolationGroupToTabletMapping;
+    private final ReentrantReadWriteLock stateLock = new ReentrantReadWriteLock();
+    private final Lock readLock = stateLock.readLock();
+    private final Lock writeLock = stateLock.writeLock();
+
+    public TabletComputeNodeMapper() {
+        resourceIsolationGroupToTabletMapping = new HashMap<>();
+    }
+
+    @TestOnly
+    public void clear() {
+        resourceIsolationGroupToTabletMapping.clear();
+    }
+
+    public int numResourceIsolationGroups() {
+        return resourceIsolationGroupToTabletMapping.size();
+    }
+
+    public void setNumReplicas(String resourceIsolationGroup, int numReplicas) {
+        writeLock.lock();
+        try {
+            maybeInitResourceIsolationGroup(resourceIsolationGroup);
+            TabletMap map = resourceIsolationGroupToTabletMapping.get(resourceIsolationGroup);
+            map.numReplicas = numReplicas;
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    public void addComputeNode(Long computeNodeId, String resourceIsolationGroup) {
+        writeLock.lock();
+        try {
+            addComputeNodeUnsynchronized(computeNodeId, resourceIsolationGroup);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    private void maybeInitResourceIsolationGroup(String resourceIsolationGroup) {
+        if (resourceIsolationGroup == null) {
+            resourceIsolationGroup = DEFAULT_RESOURCE_ISOLATION_GROUP_ID;
+        }
+        if (!resourceIsolationGroupToTabletMapping.containsKey(resourceIsolationGroup)) {
+            resourceIsolationGroupToTabletMapping.put(resourceIsolationGroup, new TabletMap());
+        }
+    }
+
+    private void addComputeNodeUnsynchronized(long computeNodeId, String resourceIsolationGroup) {
+        maybeInitResourceIsolationGroup(resourceIsolationGroup);
+        TabletMap map = resourceIsolationGroupToTabletMapping.get(resourceIsolationGroup);
+        map.tabletToComputeNodeId.addNode(computeNodeId);
+    }
+
+    // This will succeed even if the resource isolation group is not being tracked.
+    public void removeComputeNode(Long computeNodeId, String resourceIsolationGroup) {
+        writeLock.lock();
+        try {
+            removeComputeNodeUnsynchronized(computeNodeId, resourceIsolationGroup);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    private void removeComputeNodeUnsynchronized(Long computeNodeId, String resourceIsolationGroup) {
+        TabletMap map = resourceIsolationGroupToTabletMapping.get(resourceIsolationGroup);
+        if (map == null) {
+            return;
+        }
+        map.tabletToComputeNodeId.removeNode(computeNodeId);
+        if (!map.tracksSomeComputeNode()) {
+            resourceIsolationGroupToTabletMapping.remove(resourceIsolationGroup);
+        }
+    }
+
+    public void modifyComputeNode(Long computeNodeId,
+                                  String oldResourceIsolationGroup, String newResourceIsolationGroup) {
+        writeLock.lock();
+        try {
+            removeComputeNodeUnsynchronized(computeNodeId, oldResourceIsolationGroup);
+            addComputeNodeUnsynchronized(computeNodeId, newResourceIsolationGroup);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    public List<Long> computeNodesForTablet(Tablet tablet) {
+        readLock.lock();
+        try {
+            String thisResourceIsolationGroup = GlobalStateMgr.getCurrentState().getNodeMgr().getMySelf().
+                    getResourceIsolationGroup();
+            if (!this.resourceIsolationGroupToTabletMapping.containsKey(thisResourceIsolationGroup)) {
+                return null;
+            }
+            TabletMap m = this.resourceIsolationGroupToTabletMapping.get(thisResourceIsolationGroup);
+            return m.tabletToComputeNodeId.get(tablet, m.numReplicas);
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    class ComputeNodeIdFunnel implements Funnel<Long> {
+        @Override
+        public void funnel(Long computeNodeId, PrimitiveSink primitiveSink) {
+            primitiveSink.putLong(computeNodeId);
+        }
+    }
+
+    class TabletFunnel implements Funnel<Tablet> {
+        @Override
+        public void funnel(Tablet tablet, PrimitiveSink primitiveSink) {
+            primitiveSink.putLong(tablet.getId());
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/system/TabletComputeNodeMapper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/TabletComputeNodeMapper.java
@@ -34,7 +34,6 @@ package com.starrocks.system;
 import com.google.common.hash.Funnel;
 import com.google.common.hash.Hashing;
 import com.google.common.hash.PrimitiveSink;
-import com.starrocks.catalog.Tablet;
 import com.starrocks.common.util.ConsistentHashRing;
 import com.starrocks.common.util.HashRing;
 import com.starrocks.server.GlobalStateMgr;

--- a/fe/fe-core/src/test/java/com/starrocks/cluster/SystemInfoServiceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/cluster/SystemInfoServiceTest.java
@@ -54,7 +54,9 @@ import com.starrocks.sql.ast.AlterSystemStmt;
 import com.starrocks.sql.ast.DropBackendClause;
 import com.starrocks.system.Backend;
 import com.starrocks.system.ComputeNode;
+import com.starrocks.system.Frontend;
 import com.starrocks.system.NodeSelector;
+import com.starrocks.system.ResourceIsolationGroupUtils;
 import com.starrocks.system.SystemInfoService;
 import mockit.Expectations;
 import mockit.Mock;
@@ -396,6 +398,15 @@ public class SystemInfoServiceTest {
             {
                 globalStateMgr.getAnalyzer();
                 result = analyzer;
+            }
+        };
+        Frontend thisFe = new Frontend();
+        thisFe.setResourceIsolationGroup(ResourceIsolationGroupUtils.DEFAULT_RESOURCE_ISOLATION_GROUP_ID);
+        new Expectations(nodeMgr) {
+            {
+                nodeMgr.getMySelf();
+                result = thisFe;
+                minTimes = 1;
             }
         };
         com.starrocks.sql.analyzer.Analyzer.analyze(new AlterSystemStmt(stmt), new ConnectContext(null));

--- a/fe/fe-core/src/test/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProviderTest.java
@@ -26,7 +26,6 @@ import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.UserException;
-import com.starrocks.http.rest.TransactionResult;
 import com.starrocks.planner.OlapScanNode;
 import com.starrocks.planner.PlanNodeId;
 import com.starrocks.qe.ColocatedBackendSelector;

--- a/fe/fe-core/src/test/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProviderTest.java
@@ -70,13 +70,12 @@ import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import static com.starrocks.catalog.FakeGlobalStateMgr.getNodeMgr;
-
 public class DefaultSharedDataWorkerProviderTest {
     private Map<Long, ComputeNode> id2Backend;
     private Map<Long, ComputeNode> id2ComputeNode;
     private Map<Long, ComputeNode> id2AllNodes;
     private DefaultSharedDataWorkerProvider.Factory factory;
+    private Frontend thisFe;
 
     private static <C extends ComputeNode> Map<Long, C> genWorkers(long startId, long endId,
                                                                    Supplier<C> factory) {
@@ -118,6 +117,16 @@ public class DefaultSharedDataWorkerProviderTest {
             {
                 warehouseManager.getAllComputeNodeIds(anyLong);
                 result = Lists.newArrayList(id2AllNodes.keySet());
+                minTimes = 0;
+            }
+        };
+
+        thisFe = new Frontend();
+        NodeMgr nodeMgr = GlobalStateMgr.getCurrentState().getNodeMgr();
+        new Expectations(nodeMgr) {
+            {
+                nodeMgr.getMySelf();
+                result = thisFe;
                 minTimes = 0;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/persist/EditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/EditLogTest.java
@@ -14,20 +14,15 @@
 
 package com.starrocks.persist;
 
-import com.google.api.client.util.Maps;
 import com.starrocks.common.io.Text;
 import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.journal.JournalEntity;
 import com.starrocks.journal.JournalInconsistentException;
 import com.starrocks.journal.JournalTask;
-import com.starrocks.lake.LakeTablet;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.NodeMgr;
-import com.starrocks.sql.analyzer.AlterSystemStmtAnalyzer;
-import com.starrocks.sql.ast.ModifyComputeNodeClause;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.Frontend;
-import com.starrocks.system.ResourceIsolationGroupUtils;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.system.TabletComputeNodeMapper;
 import mockit.Expectations;
@@ -41,7 +36,6 @@ import org.junit.Test;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;

--- a/fe/fe-core/src/test/java/com/starrocks/persist/EditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/EditLogTest.java
@@ -14,16 +14,22 @@
 
 package com.starrocks.persist;
 
+import com.google.api.client.util.Maps;
 import com.starrocks.common.io.Text;
 import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.journal.JournalEntity;
 import com.starrocks.journal.JournalInconsistentException;
 import com.starrocks.journal.JournalTask;
+import com.starrocks.lake.LakeTablet;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.NodeMgr;
+import com.starrocks.sql.analyzer.AlterSystemStmtAnalyzer;
+import com.starrocks.sql.ast.ModifyComputeNodeClause;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.Frontend;
+import com.starrocks.system.ResourceIsolationGroupUtils;
 import com.starrocks.system.SystemInfoService;
+import com.starrocks.system.TabletComputeNodeMapper;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.apache.logging.log4j.LogManager;
@@ -35,6 +41,7 @@ import org.junit.Test;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
@@ -170,11 +177,13 @@ public class EditLogTest {
     public void testOpUpdateFrontend() throws Exception {
         GlobalStateMgr mgr = mockGlobalStateMgr();
         List<Frontend> frontends = mgr.getNodeMgr().getFrontends(null);
-        Frontend fe = frontends.get(0);
-        fe.updateHostAndEditLogPort("testHost", 1000);
-        fe.setResourceIsolationGroup("somegroup2");
+        Frontend feInMemory = frontends.get(0);
+        Frontend feToWrite = new Frontend(feInMemory.getRole(), feInMemory.getNodeName(), feInMemory.getHost(),
+                feInMemory.getEditLogPort());
+        feToWrite.updateHostAndEditLogPort("testHost", 1000);
+        feToWrite.setResourceIsolationGroup("somegroup2");
         JournalEntity journal = new JournalEntity();
-        journal.setData(fe);
+        journal.setData(feToWrite);
         journal.setOpCode(OperationType.OP_UPDATE_FRONTEND);
         EditLog editLog = new EditLog(null);
         editLog.loadJournal(mgr, journal);
@@ -188,15 +197,24 @@ public class EditLogTest {
     @Test
     public void testOpModifyComputeNode() throws Exception {
         GlobalStateMgr mgr = mockGlobalStateMgr();
-        List<ComputeNode> computeNodes = mgr.getCurrentState().getNodeMgr().getClusterInfo().getComputeNodes();
-        ComputeNode cn = computeNodes.get(0);
-        cn.setResourceIsolationGroup("somegroup");
+        SystemInfoService systemInfoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+        ComputeNode cnInMemory =  systemInfoService.getComputeNodes().get(0);
+        ComputeNode cnToWrite = new ComputeNode(cnInMemory.getId(), cnInMemory.getHost(), cnInMemory.getHeartbeatPort());
+        cnToWrite.setResourceIsolationGroup("somegroup");
         JournalEntity journal = new JournalEntity();
-        journal.setData(cn);
+        journal.setData(cnToWrite);
         journal.setOpCode(OperationType.OP_COMPUTE_NODE_STATE_CHANGE);
         EditLog editLog = new EditLog(null);
+
+        TabletComputeNodeMapper tabletComputeNodeMapper = systemInfoService.internalTabletMapper();
+        new Expectations(tabletComputeNodeMapper) {
+            {
+                tabletComputeNodeMapper.modifyComputeNode(cnToWrite.getId(), null, "somegroup");
+                minTimes = 1;
+            }
+        };
         editLog.loadJournal(mgr, journal);
-        List<ComputeNode> updatedComputeNodes = mgr.getCurrentState().getNodeMgr().getClusterInfo().getComputeNodes();
+        List<ComputeNode> updatedComputeNodes = systemInfoService.getComputeNodes();
         ComputeNode updatedCn = updatedComputeNodes.get(0);
         Assert.assertEquals("somegroup", updatedCn.getResourceIsolationGroup());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/DefaultWorkerProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/DefaultWorkerProviderTest.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Supplier;
@@ -308,7 +309,7 @@ public class DefaultWorkerProviderTest {
                 Assert.assertTrue(isContained);
             }
             // chooseBackupNode always returns -1
-            Assert.assertEquals(-1, workerProvider.selectBackupWorker(id));
+            Assert.assertEquals(-1, workerProvider.selectBackupWorker(id, Optional.empty()));
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.server;
 
-import com.google.api.client.util.Maps;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.analysis.TupleId;
@@ -22,18 +21,14 @@ import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
-import com.starrocks.catalog.Tablet;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.ExceptionChecker;
-import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.lake.StarOSAgent;
 import com.starrocks.planner.OlapScanNode;
 import com.starrocks.planner.PlanNodeId;
-import com.starrocks.sql.analyzer.AlterSystemStmtAnalyzer;
-import com.starrocks.sql.ast.ModifyComputeNodeClause;
 import com.starrocks.system.Backend;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.Frontend;
@@ -52,7 +47,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 

--- a/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
@@ -169,8 +169,8 @@ public class WarehouseManagerTest {
             }
 
             @Mock
-            public boolean usingResourceIsolationGroups() {
-                return true;
+            public boolean shouldUseInternalTabletToCnMapper() {
+                return tabletComputeNodeMapper.trackingNonDefaultResourceIsolationGroup();
             }
 
             @Mock

--- a/fe/fe-core/src/test/java/com/starrocks/system/SystemInfoServiceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/SystemInfoServiceTest.java
@@ -465,7 +465,7 @@ public class SystemInfoServiceTest {
         service.addComputeNodes(List.of(Pair.create("host1", 1000),
                                         Pair.create("host2", 1000),
                                         Pair.create("host3", 1000)));
-        Assert.assertFalse(service.usingResourceIsolationGroups());
+        Assert.assertFalse(service.shouldUseInternalTabletToCnMapper());
         List<ComputeNode> allComputeNodes = service.getComputeNodes();
         // Set all compute nodes as alive for sake of testing
         for (ComputeNode cn : allComputeNodes) {
@@ -480,7 +480,7 @@ public class SystemInfoServiceTest {
         properties.put(AlterSystemStmtAnalyzer.PROP_KEY_GROUP, "group:othergroup");
         ModifyComputeNodeClause clause = new ModifyComputeNodeClause("host3:1000", properties);
         service.modifyComputeNodeProperty(clause);
-        Assert.assertTrue(service.usingResourceIsolationGroups());
+        Assert.assertTrue(service.shouldUseInternalTabletToCnMapper());
         Assert.assertEquals(List.of(1L, 2L), service.getAvailableComputeNodeIds());
 
         // Reassign this FE and ensure it knows which compute node is available
@@ -488,7 +488,7 @@ public class SystemInfoServiceTest {
         Assert.assertEquals(List.of(3L), service.getAvailableComputeNodeIds());
 
         service.dropComputeNode("host3", 1000);
-        Assert.assertFalse(service.usingResourceIsolationGroups());
+        Assert.assertFalse(service.shouldUseInternalTabletToCnMapper());
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/system/SystemInfoServiceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/SystemInfoServiceTest.java
@@ -15,15 +15,21 @@
 package com.starrocks.system;
 
 import com.google.api.client.util.Maps;
+import com.google.common.collect.Lists;
+import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.Pair;
 import com.starrocks.persist.EditLog;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
+import com.starrocks.server.NodeMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.service.FrontendOptions;
 import com.starrocks.sql.analyzer.AlterSystemStmtAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.AddBackendClause;
+import com.starrocks.sql.ast.AlterSystemStmt;
 import com.starrocks.sql.ast.ModifyBackendClause;
 import com.starrocks.sql.ast.ModifyComputeNodeClause;
 import mockit.Expectations;
@@ -164,17 +170,6 @@ public class SystemInfoServiceTest {
         Map<String, String> properties = Maps.newHashMap();
         // missing the "group:" prefix
         properties.put(AlterSystemStmtAnalyzer.PROP_KEY_GROUP, "writegroup");
-        ModifyComputeNodeClause clause = new ModifyComputeNodeClause("originalHost:1000", properties);
-        service.modifyComputeNodeProperty(clause);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testModifyComputeNodeBadGroupProperty2ThrowsException() throws DdlException {
-        ComputeNode cn = new ComputeNode(100, "originalHost", 1000);
-        service.addComputeNode(cn);
-        Map<String, String> properties = Maps.newHashMap();
-        // bad spaces
-        properties.put(AlterSystemStmtAnalyzer.PROP_KEY_GROUP, " group : writegroup ");
         ModifyComputeNodeClause clause = new ModifyComputeNodeClause("originalHost:1000", properties);
         service.modifyComputeNodeProperty(clause);
     }
@@ -416,6 +411,84 @@ public class SystemInfoServiceTest {
         service.addComputeNode(be3);
         ComputeNode beIP3 = service.getComputeNodeWithBePort("127.0.0.2", 1001);
         Assert.assertTrue(beIP3 == null);
+    }
+
+    @Test
+    public void addComputeNodeTest() throws AnalysisException {
+        GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().dropAllBackend();
+        AddBackendClause stmt = new AddBackendClause(Lists.newArrayList("192.168.0.1:1234"));
+
+        com.starrocks.sql.analyzer.Analyzer analyzer = new com.starrocks.sql.analyzer.Analyzer(
+                com.starrocks.sql.analyzer.Analyzer.AnalyzerVisitor.getInstance());
+        new Expectations() {
+            {
+                globalStateMgr.getAnalyzer();
+                result = analyzer;
+            }
+        };
+        com.starrocks.sql.analyzer.Analyzer.analyze(new AlterSystemStmt(stmt), new ConnectContext(null));
+
+        try {
+            GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().addComputeNodes(stmt.getHostPortPairs());
+        } catch (DdlException e) {
+            Assert.fail();
+        }
+
+        Assert.assertNotNull(GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().
+                getComputeNodeWithHeartbeatPort("192.168.0.1", 1234));
+
+        try {
+            GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().addBackends(stmt.getHostPortPairs());
+        } catch (DdlException e) {
+            Assert.assertTrue(e.getMessage().contains("Compute node already exists with same host"));
+        }
+    }
+
+    @Test
+    public void resourceIsolationGroupTest() throws DdlException {
+        Frontend thisFe = new Frontend();
+        thisFe.setResourceIsolationGroup(ResourceIsolationGroupUtils.DEFAULT_RESOURCE_ISOLATION_GROUP_ID);
+        NodeMgr nodeMgr = GlobalStateMgr.getCurrentState().getNodeMgr();
+        new Expectations(nodeMgr) {
+            {
+                nodeMgr.getMySelf();
+                result = thisFe;
+                minTimes = 0;
+            }
+        };
+        new Expectations() {
+            {
+                globalStateMgr.getNextId();
+                returns(1L, 2L, 3L);
+            }
+        };
+        service.addComputeNodes(List.of(Pair.create("host1", 1000),
+                                        Pair.create("host2", 1000),
+                                        Pair.create("host3", 1000)));
+        Assert.assertFalse(service.usingResourceIsolationGroups());
+        List<ComputeNode> allComputeNodes = service.getComputeNodes();
+        // Set all compute nodes as alive for sake of testing
+        for (ComputeNode cn : allComputeNodes) {
+            cn.setAlive(true);
+        }
+        Assert.assertEquals(3, allComputeNodes.size());
+        Assert.assertEquals(3, service.getAvailableComputeNodeIds().size());
+        Assert.assertEquals(allComputeNodes, service.getAvailableComputeNodes());
+
+        // Modify host3 to belong to another non-default group and check on consequences
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put(AlterSystemStmtAnalyzer.PROP_KEY_GROUP, "group:othergroup");
+        ModifyComputeNodeClause clause = new ModifyComputeNodeClause("host3:1000", properties);
+        service.modifyComputeNodeProperty(clause);
+        Assert.assertTrue(service.usingResourceIsolationGroups());
+        Assert.assertEquals(List.of(1L, 2L), service.getAvailableComputeNodeIds());
+
+        // Reassign this FE and ensure it knows which compute node is available
+        thisFe.setResourceIsolationGroup("othergroup");
+        Assert.assertEquals(List.of(3L), service.getAvailableComputeNodeIds());
+
+        service.dropComputeNode("host3", 1000);
+        Assert.assertFalse(service.usingResourceIsolationGroups());
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/system/TabletComputeNodeMapperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/TabletComputeNodeMapperTest.java
@@ -33,8 +33,6 @@
 // under the License.
 package com.starrocks.system;
 
-import com.starrocks.catalog.Tablet;
-import com.starrocks.lake.LakeTablet;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.NodeMgr;
 import mockit.Expectations;
@@ -43,13 +41,10 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.BinaryOperator;
-import java.util.stream.Collectors;
 
 public class TabletComputeNodeMapperTest {
     private Frontend thisFe;

--- a/fe/fe-core/src/test/java/com/starrocks/system/TabletComputeNodeMapperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/TabletComputeNodeMapperTest.java
@@ -167,12 +167,14 @@ public class TabletComputeNodeMapperTest {
         for (long cnId : group1Cn) {
             int chosenCount = cnChoiceCount[(int) cnId];
             float chosenRate = (float) chosenCount / tabletsToTry;
-            Assert.assertTrue(chosenRate > .3 && chosenRate < .36);
+            // (1/num_cn_in_group_1) +- a little bit
+            Assert.assertTrue(chosenRate > .31 && chosenRate < .35);
         }
         for (long cnId : group2Cn) {
             int chosenCount = cnChoiceCount[(int) cnId];
             float chosenRate = (float) chosenCount / tabletsToTry;
-            Assert.assertTrue(chosenRate > .16 && chosenRate < .32);
+            // 2 * (1/num_cn_in_group_2) +- a little bit
+            Assert.assertTrue(chosenRate > .18 && chosenRate < .22);
         }
 
         // Check on remapping behavior after removing some CN

--- a/fe/fe-core/src/test/java/com/starrocks/system/TabletComputeNodeMapperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/TabletComputeNodeMapperTest.java
@@ -1,0 +1,202 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.starrocks.system;
+
+import com.starrocks.catalog.Tablet;
+import com.starrocks.lake.LakeTablet;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.NodeMgr;
+import mockit.Expectations;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Set;
+
+public class TabletComputeNodeMapperTest {
+    private Frontend thisFe;
+    @Before
+    public void setUp() {
+        thisFe = new Frontend();
+        thisFe.setResourceIsolationGroup(ResourceIsolationGroupUtils.DEFAULT_RESOURCE_ISOLATION_GROUP_ID);
+        NodeMgr nodeMgr = GlobalStateMgr.getCurrentState().getNodeMgr();
+        new Expectations(nodeMgr) {
+            {
+                nodeMgr.getMySelf();
+                result = thisFe;
+                minTimes = 0;
+            }
+        };
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    @Test
+    public void testGroupManagement() throws Exception {
+        TabletComputeNodeMapper mapper = new TabletComputeNodeMapper();
+        Assert.assertEquals(0, mapper.numResourceIsolationGroups());
+
+        Tablet arbitraryTablet = new LakeTablet(1000L);
+
+        // Check that the mapper returns the added compute nodes
+        mapper.addComputeNode(1L, ResourceIsolationGroupUtils.DEFAULT_RESOURCE_ISOLATION_GROUP_ID);
+        Assert.assertEquals(List.of(1L), mapper.computeNodesForTablet(arbitraryTablet));
+
+        mapper.addComputeNode(2L, ResourceIsolationGroupUtils.DEFAULT_RESOURCE_ISOLATION_GROUP_ID);
+        // Check that the mapper accurately reports the single resource isolation group.
+        Assert.assertEquals(1, mapper.numResourceIsolationGroups());
+        // Check that the default number of replicas is 1.
+        Assert.assertEquals(1, mapper.computeNodesForTablet(arbitraryTablet).size());
+
+        // check that if we set num replicas to 3 replicas,
+        // we get all the nodes in the group as long as num compute nodes in the group is <= 3.
+        mapper.setNumReplicas(ResourceIsolationGroupUtils.DEFAULT_RESOURCE_ISOLATION_GROUP_ID, 3);
+        Assert.assertEquals(2, mapper.computeNodesForTablet(arbitraryTablet).size());
+
+        mapper.addComputeNode(3L, ResourceIsolationGroupUtils.DEFAULT_RESOURCE_ISOLATION_GROUP_ID);
+        mapper.addComputeNode(4L, ResourceIsolationGroupUtils.DEFAULT_RESOURCE_ISOLATION_GROUP_ID);
+        Assert.assertEquals(3, mapper.computeNodesForTablet(arbitraryTablet).size());
+
+
+
+        String otherGroup = "someothergroup";
+        mapper.modifyComputeNode(2L, ResourceIsolationGroupUtils.DEFAULT_RESOURCE_ISOLATION_GROUP_ID,
+                otherGroup);
+        // Check that assigning the compute node to another group is reflected in the count
+        Assert.assertEquals(2, mapper.numResourceIsolationGroups());
+
+        // Check that moving the only CN from otherGroup back to the default group again reflects the count correctly
+        mapper.modifyComputeNode(2L, otherGroup,
+                ResourceIsolationGroupUtils.DEFAULT_RESOURCE_ISOLATION_GROUP_ID);
+        Assert.assertEquals(1, mapper.numResourceIsolationGroups());
+
+
+        // Check that removing the only CN from otherGroup again reflects the count correctly
+        mapper.modifyComputeNode(2L, ResourceIsolationGroupUtils.DEFAULT_RESOURCE_ISOLATION_GROUP_ID,
+                otherGroup);
+        Assert.assertEquals(2, mapper.numResourceIsolationGroups());
+        mapper.removeComputeNode(2L, otherGroup);
+        Assert.assertEquals(1, mapper.numResourceIsolationGroups());
+    }
+
+    @Test
+    public void testTabletToCnMapping() throws Exception {
+        TabletComputeNodeMapper mapper = new TabletComputeNodeMapper();
+
+        Set<Long> group1Cn = Set.of(0L, 1L, 2L);
+        Set<Long> group2Cn = Set.of(3L, 4L, 5L);
+        int[] cnChoiceCount = new int[6];
+
+        // Set up mapper for group1 and group2 to have their own CN
+        String group1 = "group1id";
+        mapper.setNumReplicas(group1, 1);
+        for (Long cnId : group1Cn) {
+            mapper.addComputeNode(cnId, group1);
+        }
+        String group2 = "group2id";
+        mapper.setNumReplicas(group2, 2);
+        for (Long cnId : group2Cn) {
+            mapper.addComputeNode(cnId, group2);
+        }
+
+        Assert.assertEquals(2, mapper.numResourceIsolationGroups());
+
+
+        int tabletsToTry = 1000;
+        long[] tabletIdToGroup2Primary = new long[tabletsToTry];
+        long[] tabletIdToGroup2Backup = new long[tabletsToTry];
+        for (long tabletId = 0; tabletId < tabletsToTry; tabletId++) {
+            Tablet arbitraryTablet = new LakeTablet(tabletId);
+            // Ensure that mapper chooses cn from right pool for fe in group1
+            thisFe.setResourceIsolationGroup(group1);
+            List<Long> chosenCn = mapper.computeNodesForTablet(arbitraryTablet);
+            Assert.assertEquals(1, chosenCn.size());
+            Assert.assertTrue(group1Cn.contains(chosenCn.get(0)));
+            // Track that the cn has been chosen for later
+            cnChoiceCount[chosenCn.get(0).intValue()] += 1;
+
+            // Ensure that mapper chooses cn from right pool for fe in group2
+            thisFe.setResourceIsolationGroup(group2);
+            chosenCn = mapper.computeNodesForTablet(arbitraryTablet);
+            // Make sure mapper respects replicas
+            Assert.assertEquals(2, chosenCn.size());
+            Assert.assertTrue(group2Cn.contains(chosenCn.get(0)));
+            Assert.assertTrue(group2Cn.contains(chosenCn.get(1)));
+            // Track that the cn have been chosen for later
+            cnChoiceCount[chosenCn.get(0).intValue()] += 1;
+            cnChoiceCount[chosenCn.get(1).intValue()] += 1;
+            tabletIdToGroup2Primary[(int) tabletId] = chosenCn.get(0);
+            tabletIdToGroup2Backup[(int) tabletId] = chosenCn.get(1);
+        }
+        // Check that the CN are chosen roughly equally.
+        for (long cnId : group1Cn) {
+            int chosenCount = cnChoiceCount[(int) cnId];
+            float chosenRate = (float) chosenCount / tabletsToTry;
+            Assert.assertTrue(chosenRate > .3 && chosenRate < .36);
+        }
+        for (long cnId : group2Cn) {
+            int chosenCount = cnChoiceCount[(int) cnId];
+            float chosenRate = (float) chosenCount / tabletsToTry;
+            Assert.assertTrue(chosenRate > .6 && chosenRate < .72);
+        }
+
+        // Check on remapping behavior after removing some CN
+        long cnIdToRemove = 4L;
+        Assert.assertTrue(group2Cn.contains(cnIdToRemove));
+        mapper.removeComputeNode(cnIdToRemove, group2);
+        thisFe.setResourceIsolationGroup(group2);
+        for (long tabletId = 0; tabletId < tabletsToTry; tabletId++) {
+            Tablet arbitraryTablet = new LakeTablet(tabletId);
+            List<Long> chosenCn = mapper.computeNodesForTablet(arbitraryTablet);
+            Assert.assertEquals(2, chosenCn.size());
+            if (tabletIdToGroup2Primary[(int) tabletId] == cnIdToRemove) {
+                // If the removed node used to be the primary, check that the old secondary is now the primary
+                Assert.assertEquals(tabletIdToGroup2Backup[(int) tabletId], (long) chosenCn.get(0));
+            } else if (tabletIdToGroup2Backup[(int) tabletId] == cnIdToRemove) {
+                // If the removed node used to be the backup, check that the primary is the same and the new secondary is
+                // not the removed node.
+                Assert.assertEquals(tabletIdToGroup2Primary[(int) tabletId], (long) chosenCn.get(0));
+                Assert.assertTrue(chosenCn.get(1) != cnIdToRemove);
+            } else {
+                // If the removed node was not a replica for the given tablet, check that the mappings haven't changed.
+                Assert.assertEquals(tabletIdToGroup2Primary[(int) tabletId], (long) chosenCn.get(0));
+                Assert.assertEquals(tabletIdToGroup2Backup[(int) tabletId], (long) chosenCn.get(1));
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/system/TabletComputeNodeMapperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/TabletComputeNodeMapperTest.java
@@ -119,7 +119,7 @@ public class TabletComputeNodeMapperTest {
 
         Set<Long> group1Cn = new java.util.HashSet<>(Set.of(0L, 1L, 2L));
         Set<Long> group2Cn = new java.util.HashSet<>(Set.of(3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L, 12L));
-        int[] cnChoiceCount = new int[group1Cn.size()+group2Cn.size()];
+        int[] cnChoiceCount = new int[group1Cn.size() + group2Cn.size()];
 
         // Set up mapper for group1 and group2 to have their own CN
         String group1 = "group1id";
@@ -207,7 +207,7 @@ public class TabletComputeNodeMapperTest {
         double stddev =
                 backupForRemovedCnToCount.values().stream().mapToDouble(val -> Math.pow(val - avg, 2)).sum();
         for (Integer count : backupForRemovedCnToCount.values()) {
-            Assert.assertTrue(Math.abs(count-avg) < stddev);
+            Assert.assertTrue(Math.abs(count - avg) < stddev);
         }
 
     }

--- a/fe/fe-core/src/test/java/com/starrocks/system/TabletComputeNodeMapperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/TabletComputeNodeMapperTest.java
@@ -67,9 +67,20 @@ public class TabletComputeNodeMapperTest {
     }
 
     @Test
+    public void testGroupManagementEdgeCase() throws Exception {
+        TabletComputeNodeMapper mapper = new TabletComputeNodeMapper();
+        Assert.assertEquals(0, mapper.numResourceIsolationGroups());
+        Assert.assertFalse(mapper.trackingNonDefaultResourceIsolationGroup());
+        mapper.addComputeNode(1L, "randomgroup");
+        Assert.assertTrue(mapper.trackingNonDefaultResourceIsolationGroup());
+    }
+
+
+    @Test
     public void testGroupManagement() throws Exception {
         TabletComputeNodeMapper mapper = new TabletComputeNodeMapper();
         Assert.assertEquals(0, mapper.numResourceIsolationGroups());
+        Assert.assertFalse(mapper.trackingNonDefaultResourceIsolationGroup());
 
         Long arbitraryTablet = 1000L;
 
@@ -90,20 +101,19 @@ public class TabletComputeNodeMapperTest {
         mapper.addComputeNode(3L, ResourceIsolationGroupUtils.DEFAULT_RESOURCE_ISOLATION_GROUP_ID);
         mapper.addComputeNode(4L, ResourceIsolationGroupUtils.DEFAULT_RESOURCE_ISOLATION_GROUP_ID);
         Assert.assertEquals(3, mapper.computeNodesForTablet(arbitraryTablet, 3).size());
-
-
+        Assert.assertFalse(mapper.trackingNonDefaultResourceIsolationGroup());
 
         String otherGroup = "someothergroup";
         mapper.modifyComputeNode(2L, ResourceIsolationGroupUtils.DEFAULT_RESOURCE_ISOLATION_GROUP_ID,
                 otherGroup);
         // Check that assigning the compute node to another group is reflected in the count
         Assert.assertEquals(2, mapper.numResourceIsolationGroups());
+        Assert.assertTrue(mapper.trackingNonDefaultResourceIsolationGroup());
 
         // Check that moving the only CN from otherGroup back to the default group again reflects the count correctly
         mapper.modifyComputeNode(2L, otherGroup,
                 ResourceIsolationGroupUtils.DEFAULT_RESOURCE_ISOLATION_GROUP_ID);
         Assert.assertEquals(1, mapper.numResourceIsolationGroups());
-
 
         // Check that removing the only CN from otherGroup again reflects the count correctly
         mapper.modifyComputeNode(2L, ResourceIsolationGroupUtils.DEFAULT_RESOURCE_ISOLATION_GROUP_ID,


### PR DESCRIPTION
## What I'm doing:
* When compute nodes have a resource group set, have FE start to manage its own mappings from tablet to compute node, one distinct mapping per resource isolation group. This means delegating to an internal data structure, the singleton `TabletComputeNodeMapper` and bypassing StarOS/StarMgr. This is a significant change to the way StarRocks functions. 
* Whenever there's node selection, return compute nodes which have the same resource isolation group as the current FE
* Improve CN backup selection behavior that kicks in when there's some CN removed or unhealthy: instead of using a single CN as backup for the unhealthy CN, evenly distribute the load originally meant for the unhealthy CN to remaining CN. This is accomplished using consistent hashing with vnodes. 
## Why I'm doing:

* This is part of the implementation of the [Resource Isolation for Shared Data Mode feature](https://docs.google.com/document/d/1oZx-h9bcf7pW_xQSwQyh5ciGjFMxprIrqItPBsKV5G8/edit#heading=h.6jjpflfxnimt)
* This preps the "multiple replicas for shared data mode" feature

Follow up PRs to come which will
* Add the resource isolation group labels to CACHE SELECT statements and implementation of warming up multiple replicas
* Start returning resource isolation groups with `SHOW FRONTENDS` and `SHOW COMPUTE NODES`
See other [milestones](https://docs.google.com/document/d/1Wv1R20gd6DNr5r3dMJQWowQjx7i8UQsHD8s49yk0ei4/edit#heading=h.wgshf257oc6o)
* Start leveraging our new mappings to enable multiple replicas in shared data mode, details to be determined. 
Fixes #issue https://jira.pinadmin.com/browse/RTA-6269

## Testing
Testing ongoing in dev7, asking for review in parallel


## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
