### PR TITLE
Bugfix NPE that occurs during version upgrade with empty/default resource isolation group

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTablet.java
@@ -140,6 +140,9 @@ public class LakeTablet extends Tablet {
                                      long visibleVersion, long localBeId, int schemaHash, long warehouseId) {
         Set<Long> computeNodeIds = GlobalStateMgr.getCurrentState().getWarehouseMgr()
                 .getAllComputeNodeIdsAssignToTablet(warehouseId, this);
+        if (computeNodeIds == null) {
+            return;
+        }
         for (long backendId : computeNodeIds) {
             Replica replica = new Replica(getId(), backendId, visibleVersion, schemaHash, getDataSize(true),
                     getRowCount(visibleVersion), NORMAL, -1, visibleVersion);

--- a/fe/fe-core/src/main/java/com/starrocks/server/WarehouseManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/WarehouseManager.java
@@ -37,6 +37,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -207,8 +208,10 @@ public class WarehouseManager implements Writable {
                         " warehouse %d", warehouseId));
             }
             List<Long> computeNodeIds = systemInfoService.internalTabletMapper().computeNodesForTablet(tablet.getId());
-            if (computeNodeIds == null) {
-                return null;
+            if (computeNodeIds == null || computeNodeIds.isEmpty()) {
+                LOG.warn("no compute nodes assigned to tablet {} in warehouse {}", tablet.getId(),
+                        warehouseId);
+                return Collections.emptySet();
             }
             return new HashSet<>(computeNodeIds);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterSystemStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterSystemStmtAnalyzer.java
@@ -163,7 +163,8 @@ public class AlterSystemStmtAnalyzer implements AstVisitor<Void, ConnectContext>
                     continue;
                 }
                 // Support single level location label for now
-                String regex = "(\\s*[a-z_0-9]+\\s*:\\s*[a-z_0-9]+\\s*)";
+                // allow matching an empty val (after the colon)
+                String regex = "(\\s*[a-z_0-9]+\\s*:\\s*[a-z_0-9]*\\s*)";
                 if (!Pattern.compile(regex).matcher(propVal).matches()) {
                     throw new SemanticException("invalid 'location' or 'group' format: " + propVal +
                             ", should be like: 'key:val'");

--- a/fe/fe-core/src/main/java/com/starrocks/system/TabletComputeNodeMapper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/TabletComputeNodeMapper.java
@@ -203,7 +203,7 @@ public class TabletComputeNodeMapper {
             if (!this.resourceIsolationGroupToTabletMapping.containsKey(resourceIsolationGroup)) {
                 LOG.warn(String.format("Requesting node for resource isolation group %s, to which"
                         + " there is not a known CN assigned.", resourceIsolationGroup));
-                return null;
+                return Collections.emptyList();
             }
             TabletMap m = this.resourceIsolationGroupToTabletMapping.get(resourceIsolationGroup);
             return m.tabletToComputeNodeId.get(tabletId, count);

--- a/fe/fe-core/src/main/java/com/starrocks/system/TabletComputeNodeMapper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/TabletComputeNodeMapper.java
@@ -37,6 +37,8 @@ import com.google.common.hash.PrimitiveSink;
 import com.starrocks.common.util.ConsistentHashRing;
 import com.starrocks.common.util.HashRing;
 import com.starrocks.server.GlobalStateMgr;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.TestOnly;
 
 import java.util.Collections;
@@ -65,6 +67,7 @@ import static com.starrocks.system.ResourceIsolationGroupUtils.DEFAULT_RESOURCE_
  */
 
 public class TabletComputeNodeMapper {
+    private static final Logger LOG = LogManager.getLogger(TabletComputeNodeMapper.class);
 
     private static final int CONSISTENT_HASH_RING_VIRTUAL_NUMBER = 256;
     private static final Long ARBITRARY_FAKE_TABLET = 1L;
@@ -169,9 +172,12 @@ public class TabletComputeNodeMapper {
                                   String oldResourceIsolationGroup, String newResourceIsolationGroup) {
         oldResourceIsolationGroup = getResourceIsolationGroupName(oldResourceIsolationGroup);
         newResourceIsolationGroup = getResourceIsolationGroupName(newResourceIsolationGroup);
-        if (oldResourceIsolationGroup.equals(newResourceIsolationGroup)) {
-            return;
-        }
+        // We run the following even if oldResourceIsolationGroup.equals(newResourceIsolationGroup)
+        // because we want to cleanly handle edge cases where the compute node hasn't already been
+        // added to the TabletComputeNode mapper. This can happen in at least one situation, which
+        // is when the cluster is first upgraded to include resource isolation groups.
+        // Because the host ips match during a CN restart, upstream code which adds the ComputeNodes
+        // will not execute and therefore we won't call this.addComputeNode.
         writeLock.lock();
         try {
             removeComputeNodeUnsynchronized(computeNodeId, oldResourceIsolationGroup);
@@ -195,6 +201,8 @@ public class TabletComputeNodeMapper {
         readLock.lock();
         try {
             if (!this.resourceIsolationGroupToTabletMapping.containsKey(resourceIsolationGroup)) {
+                LOG.warn(String.format("Requesting node for resource isolation group %s, to which"
+                        + " there is not a known CN assigned.", resourceIsolationGroup));
                 return null;
             }
             TabletMap m = this.resourceIsolationGroupToTabletMapping.get(resourceIsolationGroup);

--- a/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
@@ -143,12 +143,12 @@ public class WarehouseManagerTest {
             public SystemInfoService getClusterInfo() {
                 return systemInfo;
             }
+
             @Mock
             public Frontend getMySelf() {
                 return thisFe;
             }
         };
-
 
         TabletComputeNodeMapper tabletComputeNodeMapper = new TabletComputeNodeMapper();
         tabletComputeNodeMapper.addComputeNode(1L, thisFe.getResourceIsolationGroup());
@@ -191,12 +191,12 @@ public class WarehouseManagerTest {
         mgr.initDefaultWarehouse();
 
         LakeTablet arbitraryTablet = new LakeTablet(1001L);
-        Assert.assertEquals(Set.of(1L), mgr.getAllComputeNodeIdsAssignToTablet(
-                WarehouseManager.DEFAULT_WAREHOUSE_ID, arbitraryTablet));
+        Assert.assertEquals(Set.of(1L),
+                mgr.getAllComputeNodeIdsAssignToTablet(WarehouseManager.DEFAULT_WAREHOUSE_ID, arbitraryTablet));
 
         thisFe.setResourceIsolationGroup(otherResourceIsolationGroup);
-        Assert.assertEquals(Set.of(2L), mgr.getAllComputeNodeIdsAssignToTablet(
-                WarehouseManager.DEFAULT_WAREHOUSE_ID, arbitraryTablet));
+        Assert.assertEquals(Set.of(2L),
+                mgr.getAllComputeNodeIdsAssignToTablet(WarehouseManager.DEFAULT_WAREHOUSE_ID, arbitraryTablet));
 
         // Check that WarehouseManager.getAllComputeNodeIdsAssignToTablet delegates to
         // systemInfo.getAvailableComputeNodeIds.
@@ -365,7 +365,10 @@ public class WarehouseManagerTest {
         MaterializedIndex index = new MaterializedIndex(1, MaterializedIndex.IndexState.NORMAL);
         ErrorReportException ex = Assert.assertThrows(ErrorReportException.class,
                 () -> scanNode.addScanRangeLocations(partition, partition, index, Collections.emptyList(), 1));
-        Assert.assertEquals("No alive backend or compute node in warehouse null. Also possible that there are no CN of the resource isolation group matching the FE.", ex.getMessage());
+        Assert.assertEquals(
+                "No alive backend or compute node in warehouse null. Also possible that there are no CN of the resource " +
+                        "isolation group matching the FE.",
+                ex.getMessage());
     }
 
     private OlapScanNode newOlapScanNode() {

--- a/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
@@ -365,7 +365,7 @@ public class WarehouseManagerTest {
         MaterializedIndex index = new MaterializedIndex(1, MaterializedIndex.IndexState.NORMAL);
         ErrorReportException ex = Assert.assertThrows(ErrorReportException.class,
                 () -> scanNode.addScanRangeLocations(partition, partition, index, Collections.emptyList(), 1));
-        Assert.assertEquals("No alive backend or compute node in warehouse null.", ex.getMessage());
+        Assert.assertEquals("No alive backend or compute node in warehouse null. Also possible that there are no CN of the resource isolation group matching the FE.", ex.getMessage());
     }
 
     private OlapScanNode newOlapScanNode() {

--- a/fe/fe-core/src/test/java/com/starrocks/system/TabletComputeNodeMapperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/TabletComputeNodeMapperTest.java
@@ -67,6 +67,17 @@ public class TabletComputeNodeMapperTest {
     }
 
     @Test
+    public void modifyComputeNodeEdgeCases() throws Exception {
+        Long arbitraryTablet = 9000L;
+        TabletComputeNodeMapper mapper = new TabletComputeNodeMapper();
+        Assert.assertEquals(0, mapper.numResourceIsolationGroups());
+        Assert.assertNull(mapper.computeNodesForTablet(arbitraryTablet, 1, ""));
+        mapper.modifyComputeNode(1L, "", "");
+        Assert.assertEquals(1, mapper.numResourceIsolationGroups());
+        Assert.assertEquals(List.of(1L), mapper.computeNodesForTablet(arbitraryTablet, 1, ""));
+    }
+
+    @Test
     public void testGroupManagementEdgeCase() throws Exception {
         TabletComputeNodeMapper mapper = new TabletComputeNodeMapper();
         Assert.assertEquals(0, mapper.numResourceIsolationGroups());

--- a/fe/fe-core/src/test/java/com/starrocks/system/TabletComputeNodeMapperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/TabletComputeNodeMapperTest.java
@@ -35,13 +35,13 @@ package com.starrocks.system;
 
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.NodeMgr;
-import java.util.Collections;
 import mockit.Expectations;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -49,6 +49,7 @@ import java.util.Set;
 
 public class TabletComputeNodeMapperTest {
     private Frontend thisFe;
+
     @Before
     public void setUp() {
         thisFe = new Frontend();
@@ -86,7 +87,6 @@ public class TabletComputeNodeMapperTest {
         mapper.addComputeNode(1L, "randomgroup");
         Assert.assertTrue(mapper.trackingNonDefaultResourceIsolationGroup());
     }
-
 
     @Test
     public void testGroupManagement() throws Exception {
@@ -154,7 +154,6 @@ public class TabletComputeNodeMapperTest {
         }
 
         Assert.assertEquals(2, mapper.numResourceIsolationGroups());
-
 
         int tabletsToTry = 10000;
         long[] tabletIdToGroup2Primary = new long[tabletsToTry];

--- a/fe/fe-core/src/test/java/com/starrocks/system/TabletComputeNodeMapperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/TabletComputeNodeMapperTest.java
@@ -35,6 +35,7 @@ package com.starrocks.system;
 
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.NodeMgr;
+import java.util.Collections;
 import mockit.Expectations;
 import org.junit.After;
 import org.junit.Assert;
@@ -71,7 +72,7 @@ public class TabletComputeNodeMapperTest {
         Long arbitraryTablet = 9000L;
         TabletComputeNodeMapper mapper = new TabletComputeNodeMapper();
         Assert.assertEquals(0, mapper.numResourceIsolationGroups());
-        Assert.assertNull(mapper.computeNodesForTablet(arbitraryTablet, 1, ""));
+        Assert.assertEquals(Collections.emptyList(), mapper.computeNodesForTablet(arbitraryTablet, 1, ""));
         mapper.modifyComputeNode(1L, "", "");
         Assert.assertEquals(1, mapper.numResourceIsolationGroups());
         Assert.assertEquals(List.of(1L), mapper.computeNodesForTablet(arbitraryTablet, 1, ""));


### PR DESCRIPTION
## Why I'm doing:
When upgrading for the first time to use resource isolation groups, there's an issue where the TabletComputeNodeMapper doesn't know about the default/empty resource isolation group, due to the way that the `modifyComputeNode` function worked.

## What I'm doing:

* `modifyComputeNode` is idempotent, so we'll let it run regardless of whether the old and new resource isolation groups match. 
* Also, improve situations where a resource isolation group has no CN, by returning empty collections instead of null, which reduces chances for NPE. 
* Also expand parsing of resource isolation group in statements to allow unsetting/setting-to-empty the resource isolation group. 

Fixes #issue https://jira.pinadmin.com/browse/RTA-6269

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
