### PR TITLE
Bugfix for TabletComputeNodeMapper falling out of sync with which CN belongs to which resource isolation group + additional visibility into tablet->CN mappings

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/ComputeNodeProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/ComputeNodeProcDir.java
@@ -60,7 +60,11 @@ public class ComputeNodeProcDir implements ProcDirInterface {
                 .add("WorkerId")
                 .add("WarehouseName")
                 .add("TabletNum")
-                .add("UsedForTabletScanCount")
+                // This field is meant to help us understand how often we're using this CN to scan any tablet. It's meant to help
+                // us detect if some tablet which this CN currently "owns" is very hot. It's about relative magnitude with a given
+                // FE. If some CN have very high values for this field and other CN have very low values, we know the
+                // TabletComputeNodeMapper is not doing a good job distributing load across CN.
+                .add("OwnedTabletScanCount")
                 .add("ResourceIsolationGroup");
         TITLE_NAMES_SHARED_DATA = builder.build();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/ComputeNodeProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/ComputeNodeProcDir.java
@@ -34,6 +34,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -59,6 +60,7 @@ public class ComputeNodeProcDir implements ProcDirInterface {
                 .add("WorkerId")
                 .add("WarehouseName")
                 .add("TabletNum")
+                .add("UsedForTabletScanCount")
                 .add("ResourceIsolationGroup");
         TITLE_NAMES_SHARED_DATA = builder.build();
     }
@@ -104,6 +106,14 @@ public class ComputeNodeProcDir implements ProcDirInterface {
         if (computeNodeIds == null) {
             return computeNodesInfos;
         }
+
+        boolean usingInternalMapper = clusterInfoService.shouldUseInternalTabletToCnMapper();
+        Map<Long, Long> computeNodeToOwnedTabletCount = null;
+        if (usingInternalMapper) {
+            // Note that this will only return information about tablets which this FE has needed to scan.
+            computeNodeToOwnedTabletCount = clusterInfoService.internalTabletMapper().computeNodeToOwnedTabletCount();
+        }
+
 
         long start = System.currentTimeMillis();
         Stopwatch watch = Stopwatch.createUnstarted();
@@ -176,9 +186,21 @@ public class ComputeNodeProcDir implements ProcDirInterface {
                 Warehouse wh = GlobalStateMgr.getCurrentState().getWarehouseMgr().getWarehouse(computeNode.getWarehouseId());
                 computeNodeInfo.add(wh.getName());
 
-                String workerAddr = computeNode.getHost() + ":" + computeNode.getStarletPort();
-                long tabletNum = GlobalStateMgr.getCurrentState().getStarOSAgent().getWorkerTabletNum(workerAddr);
-                computeNodeInfo.add(tabletNum);
+                // If we're using resource isolation groups, we bypass the call to StarOS/StarMgr
+                if (usingInternalMapper) {
+                    Long tabletNum = computeNodeToOwnedTabletCount.getOrDefault(computeNodeId, 0L);
+                    computeNodeInfo.add(tabletNum);
+
+                    Long tabletsScannedCount = clusterInfoService.internalTabletMapper().getComputeNodeReturnCount(computeNodeId);
+                    computeNodeInfo.add(tabletsScannedCount);
+                } else {
+                    String workerAddr = computeNode.getHost() + ":" + computeNode.getStarletPort();
+                    long tabletNum = GlobalStateMgr.getCurrentState().getStarOSAgent().getWorkerTabletNum(workerAddr);
+                    computeNodeInfo.add(tabletNum);
+                    // We haven't tracked the "used for tablet scan count" in this case
+                    computeNodeInfo.add("unknown");
+                }
+
                 computeNodeInfo.add(computeNode.getResourceIsolationGroup());
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/ProcService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/ProcService.java
@@ -72,6 +72,7 @@ public final class ProcService {
         root.register("compactions", new CompactionsProcNode());
         root.register("meta_recovery", new MetaRecoveryProdDir());
         root.register("replications", new ReplicationsProcNode());
+        root.register("tablet_mapping", new TabletMappingProcNode());
     }
 
     // Get the corresponding PROC Node by the specified path

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/TabletMappingProcNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/TabletMappingProcNode.java
@@ -1,0 +1,91 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.common.proc;
+
+import com.google.common.collect.ImmutableList;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.system.SystemInfoService;
+import com.starrocks.system.TabletComputeNodeMapper;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+/*
+    This class is responsible for giving information about Tablets. It is limited in that it will only report information about
+     tablets which this FE has needed to scan to fulfill a query which it received since it came up.
+ */
+public class TabletMappingProcNode implements ProcDirInterface {
+
+    private static final Logger LOG = LogManager.getLogger(TabletMappingProcNode.class);
+
+    public static final ImmutableList<String> TITLE_NAMES;
+
+    static {
+        ImmutableList.Builder<String> builder =
+                new ImmutableList.Builder<String>().add("TabletId").add("RequestCount").add("PrimaryCnOwner")
+                        .add("SecondaryCnOwner");
+        TITLE_NAMES = builder.build();
+    }
+
+    @Override
+    public ProcResult fetchResult() throws AnalysisException {
+        final SystemInfoService clusterInfoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+        if (!clusterInfoService.shouldUseInternalTabletToCnMapper()) {
+            LOG.warn("Requesting tablet mapping information but it's not internally maintained.");
+            BaseProcResult result = new BaseProcResult();
+            result.setNames(List.of("N/A"));
+            result.addRow(List.of("Tablet mapping information not internally maintained"));
+            return result;
+        }
+
+        BaseProcResult result = new BaseProcResult();
+        result.setNames(TITLE_NAMES);
+        final TabletComputeNodeMapper tabletComputeNodeMapper = clusterInfoService.internalTabletMapper();
+
+        for (Map.Entry<Long, AtomicLong> tabletToMappingCount : tabletComputeNodeMapper.getTabletMappingCount().entrySet()) {
+            List<String> tabletInfo = new ArrayList<>(TITLE_NAMES.size());
+
+            tabletInfo.add(tabletToMappingCount.getKey().toString());
+            tabletInfo.add(tabletToMappingCount.getValue().toString());
+
+            List<Long> computeNodeIds = tabletComputeNodeMapper.computeNodesForTablet(tabletToMappingCount.getKey(), 2);
+            for (Long computeNodeId : computeNodeIds) {
+                tabletInfo.add(computeNodeId.toString());
+            }
+            while (tabletInfo.size() < TITLE_NAMES.size()) {
+                // If there's only 1 CN in this resource isolation group, there can be no SecondaryCnOwner,
+                // fill in the row to reflect that.
+                tabletInfo.add("N/A");
+            }
+            result.addRow(tabletInfo);
+        }
+        return result;
+    }
+
+    @Override
+    public boolean register(String name, ProcNodeInterface node) {
+        return true;
+    }
+
+    @Override
+    public ProcNodeInterface lookup(String name) throws AnalysisException {
+        return null;
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/TabletMappingProcNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/TabletMappingProcNode.java
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicLong;
 /*
     This class is responsible for giving information about Tablets. It is limited in that it will only report information about
      tablets which this FE has needed to scan to fulfill a query which it received since it came up.
+     This is meant to help us understand if some tablet is very hot right now, and to know which CN is/are handling that load.
  */
 public class TabletMappingProcNode implements ProcDirInterface {
 
@@ -64,6 +65,7 @@ public class TabletMappingProcNode implements ProcDirInterface {
             tabletInfo.add(tabletToMappingCount.getKey().toString());
             tabletInfo.add(tabletToMappingCount.getValue().toString());
 
+            // We ask for 2 compute node ids since we're outputting the main tablet owner and the first backup.
             List<Long> computeNodeIds = tabletComputeNodeMapper.computeNodesForTablet(tabletToMappingCount.getKey(), 2);
             for (Long computeNodeId : computeNodeIds) {
                 tabletInfo.add(computeNodeId.toString());

--- a/fe/fe-core/src/main/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProvider.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Sets;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.FeConstants;
+import com.starrocks.common.util.LogUtil;
 import com.starrocks.qe.SessionVariableConstants.ComputationFragmentSchedulingPolicy;
 import com.starrocks.qe.SimpleScheduler;
 import com.starrocks.qe.scheduler.NonRecoverableException;
@@ -234,6 +235,7 @@ public class DefaultSharedDataWorkerProvider implements WorkerProvider {
     }
 
     private void reportWorkerNotFoundException(long workerId) throws NonRecoverableException {
+        LOG.error("Worker not found {}", LogUtil.getCurrentStackTrace());
         throw new NonRecoverableException(
                 FeConstants.getNodeNotFoundError(true) + " nodeId: " + workerId + " " + this);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/server/WarehouseManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/WarehouseManager.java
@@ -138,7 +138,7 @@ public class WarehouseManager implements Writable {
                 throw new IllegalArgumentException(String.format("Cannot use resource groups with non-default" +
                         " warehouse %d or non-default worker group id %d", warehouseId, workerGroupId));
             }
-            return systemInfoService.getAvailableComputeNodeIds();
+            return systemInfoService.getRigMatchingComputeNodeIds();
         }
 
 

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -968,6 +968,21 @@ public class SystemInfoService implements GsonPostProcessable {
         return backendIds;
     }
 
+    public List<Long> getRigMatchingComputeNodeIds() {
+        String thisResourceIsolationGroup = GlobalStateMgr.getCurrentState().getNodeMgr().getMySelf().
+                getResourceIsolationGroup();
+        List<Long> computeNodeIds = Lists.newArrayList(idToComputeNodeRef.keySet());
+
+        Iterator<Long> iter = computeNodeIds.iterator();
+        while (iter.hasNext()) {
+            ComputeNode cn = this.getComputeNode(iter.next());
+            if (cn == null || !resourceIsolationGroupMatches(cn.getResourceIsolationGroup(), thisResourceIsolationGroup)) {
+                iter.remove();
+            }
+        }
+        return computeNodeIds;
+    }
+
     public List<Long> getAvailableComputeNodeIds() {
         String thisResourceIsolationGroup = GlobalStateMgr.getCurrentState().getNodeMgr().getMySelf().
                 getResourceIsolationGroup();
@@ -1323,6 +1338,10 @@ public class SystemInfoService implements GsonPostProcessable {
             idToReportVersion.put(beId, new AtomicLong(0));
         }
         idToReportVersionRef = ImmutableMap.copyOf(idToReportVersion);
+
+        for (Map.Entry<Long, ComputeNode> cn : idToComputeNodeRef.entrySet()) {
+            tabletComputeNodeMapper.addComputeNode(cn.getKey(), cn.getValue().getResourceIsolationGroup());
+        }
 
         // BackendCoreStat is a global state, checkpoint should not modify it.
         if (!GlobalStateMgr.isCheckpointThread()) {

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -1121,8 +1121,8 @@ public class SystemInfoService implements GsonPostProcessable {
         // update idToComputeNode
         newComputeNode.setBackendState(BackendState.using);
         idToComputeNodeRef.put(newComputeNode.getId(), newComputeNode);
-        // TODO(cbrennan) Should this be using the given newComputeNode resource isolation group?
-        //  Technically the modify should get replayed right?
+        // Technically the modify which assigns a non-default resource isolation group should always be replayed after the ADD
+        // COMPUTE NODE is replayed, but it can't hurt to call getResourceIsolationGroup in any case.
         tabletComputeNodeMapper.addComputeNode(newComputeNode.getId(), newComputeNode.getResourceIsolationGroup());
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -1106,7 +1106,9 @@ public class SystemInfoService implements GsonPostProcessable {
         // update idToComputeNode
         newComputeNode.setBackendState(BackendState.using);
         idToComputeNodeRef.put(newComputeNode.getId(), newComputeNode);
-        tabletComputeNodeMapper.addComputeNode(newComputeNode.getId(), DEFAULT_RESOURCE_ISOLATION_GROUP_ID);
+        // TODO(cbrennan) Should this be using the given newComputeNode resource isolation group?
+        //  Technically the modify should get replayed right?
+        tabletComputeNodeMapper.addComputeNode(newComputeNode.getId(), newComputeNode.getResourceIsolationGroup());
     }
 
     public void replayAddBackend(Backend newBackend) {

--- a/fe/fe-core/src/main/java/com/starrocks/system/TabletComputeNodeMapper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/TabletComputeNodeMapper.java
@@ -128,7 +128,8 @@ public class TabletComputeNodeMapper {
 
     public String debugString() {
         return resourceIsolationGroupToTabletMapping.entrySet().stream()
-                .map(entry -> String.format("%-15s : %s", entry.getKey(), entry.getValue())).collect(Collectors.joining("\n"));
+                .map(entry -> String.format("%-15s : %s", entry.getKey(), entry.getValue()))
+                .collect(Collectors.joining("\n"));
     }
 
     public void addComputeNode(Long computeNodeId, String resourceIsolationGroup) {

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/TabletMappingProcNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/TabletMappingProcNodeTest.java
@@ -1,0 +1,210 @@
+package com.starrocks.common.proc;
+
+import com.google.common.collect.Maps;
+import com.starrocks.lake.StarOSAgent;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.NodeMgr;
+import com.starrocks.system.SystemInfoService;
+import com.starrocks.system.TabletComputeNodeMapper;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class TabletMappingProcNodeTest {
+    @Mocked
+    private GlobalStateMgr globalStateMgr;
+    @Mocked
+    private StarOSAgent starOsAgent;
+    @Mocked
+    private NodeMgr nodeMgr;
+    @Mocked
+    private SystemInfoService systemInfoService;
+    @Mocked
+    private TabletComputeNodeMapper tabletComputeNodeMapper;
+
+    @Before
+    public void setUp() {
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                minTimes = 1;
+                result = globalStateMgr;
+            }
+        };
+
+        new Expectations(globalStateMgr) {
+            {
+                globalStateMgr.getNodeMgr();
+                minTimes = 1;
+                result = nodeMgr;
+            }
+        };
+
+        new Expectations(nodeMgr) {
+            {
+                nodeMgr.getClusterInfo();
+                minTimes = 1;
+                result = systemInfoService;
+            }
+        };
+    }
+
+    @Test
+    public void testNoTabletMappings() throws Exception {
+        new Expectations(systemInfoService) {
+            {
+                systemInfoService.shouldUseInternalTabletToCnMapper();
+                minTimes = 1;
+                result = true;
+            }
+
+            {
+                systemInfoService.internalTabletMapper();
+                minTimes = 1;
+                result = tabletComputeNodeMapper;
+            }
+        };
+
+        // Check that when there's no tablet mappings this doesn't break.
+        new Expectations(tabletComputeNodeMapper) {
+            {
+                tabletComputeNodeMapper.getTabletMappingCount();
+                times = 1;
+                result = Maps.newConcurrentMap();
+
+            }
+        };
+        TabletMappingProcNode proceNode = new TabletMappingProcNode();
+        ProcResult res = proceNode.fetchResult();
+    }
+
+    @Test
+    public void testNoComputeNodes() throws Exception {
+        new Expectations(systemInfoService) {
+            {
+                systemInfoService.shouldUseInternalTabletToCnMapper();
+                minTimes = 1;
+                result = true;
+            }
+
+            {
+                systemInfoService.internalTabletMapper();
+                minTimes = 1;
+                result = tabletComputeNodeMapper;
+            }
+        };
+
+        // Check that when there's no compute nodes this doesn't break.
+        ConcurrentMap<Long, AtomicLong> tabletToMappingCount = Maps.newConcurrentMap();
+        tabletToMappingCount.put(1L, new AtomicLong(10));
+
+        new Expectations(tabletComputeNodeMapper) {
+            {
+                tabletComputeNodeMapper.getTabletMappingCount();
+                times = 1;
+                result = tabletToMappingCount;
+
+            }
+
+            {
+                tabletComputeNodeMapper.computeNodesForTablet(1L, 2);
+                times = 1;
+                result = List.of();
+            }
+        };
+        TabletMappingProcNode proceNode = new TabletMappingProcNode();
+        ProcResult res = proceNode.fetchResult();
+    }
+
+    @Test
+    public void testOneComputeNodes() throws Exception {
+        new Expectations(systemInfoService) {
+            {
+                systemInfoService.shouldUseInternalTabletToCnMapper();
+                minTimes = 1;
+                result = true;
+            }
+
+            {
+                systemInfoService.internalTabletMapper();
+                minTimes = 1;
+                result = tabletComputeNodeMapper;
+            }
+        };
+
+        // Check that when there's only one compute node this doesn't break.
+        ConcurrentMap<Long, AtomicLong> tabletToMappingCount = Maps.newConcurrentMap();
+        tabletToMappingCount.put(1L, new AtomicLong(10));
+
+        new Expectations(tabletComputeNodeMapper) {
+            {
+                tabletComputeNodeMapper.getTabletMappingCount();
+                times = 1;
+                result = tabletToMappingCount;
+
+            }
+
+            {
+                tabletComputeNodeMapper.computeNodesForTablet(1L, 2);
+                times = 1;
+                result = List.of(100L);
+            }
+        };
+        TabletMappingProcNode proceNode = new TabletMappingProcNode();
+        ProcResult res = proceNode.fetchResult();
+    }
+
+    @Test
+    public void testNormal() throws Exception {
+        new Expectations(systemInfoService) {
+            {
+                systemInfoService.shouldUseInternalTabletToCnMapper();
+                minTimes = 1;
+                result = true;
+            }
+
+            {
+                systemInfoService.internalTabletMapper();
+                minTimes = 1;
+                result = tabletComputeNodeMapper;
+            }
+        };
+
+        // Check that when there's multiple tablets and multiple CN this doesn't break
+        ConcurrentMap<Long, AtomicLong> tabletToMappingCount = Maps.newConcurrentMap();
+        tabletToMappingCount.put(1L, new AtomicLong(10));
+        tabletToMappingCount.put(2L, new AtomicLong(20));
+
+        new Expectations(tabletComputeNodeMapper) {
+            {
+                tabletComputeNodeMapper.getTabletMappingCount();
+                times = 1;
+                result = tabletToMappingCount;
+
+            }
+
+            {
+                tabletComputeNodeMapper.computeNodesForTablet(1L, 2);
+                times = 1;
+                result = List.of(100L, 200L);
+            }
+
+            {
+                tabletComputeNodeMapper.computeNodesForTablet(2L, 2);
+                times = 1;
+                result = List.of(200L, 300L);
+            }
+        };
+        TabletMappingProcNode proceNode = new TabletMappingProcNode();
+        ProcResult res = proceNode.fetchResult();
+
+        Assert.assertEquals(List.of("TabletId", "RequestCount", "PrimaryCnOwner", "SecondaryCnOwner"), res.getColumnNames());
+        Assert.assertEquals(List.of(List.of("1", "10", "100", "200"), List.of("2", "20", "200", "300")), res.getRows());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/TabletMappingProcNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/TabletMappingProcNodeTest.java
@@ -1,3 +1,17 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.starrocks.common.proc;
 
 import com.google.common.collect.Maps;


### PR DESCRIPTION
## Why I'm doing:
There's a bug where compute nodes gradually fall out of the correct resource isolation group map in the `TabletComputeNodeMapper`. My assumption was that when replaying addComputeNode statements we could always initially assign the default resource isolation group, since the modifyComputeNode should always be replayed soon after. This does not appear to be the case, because sometimes the SystemInfoService is rebuilt by deserializing it from an image, instead of by replaying all state-modifying transactions. Without this bug fix, it appears that eventually, the TabletComputeNode state ends up having all CN assigned to the default resource isolation group, which is a problem when the FE are not assigned to the default resource isolation group. 

I've deployed this in a dev environment and it fixes the issues I've observed. 

## What I'm doing:

1. Bug fix: post-deserialization of `SystemInfoService` in `gsonPostProcess`, add the compute nodes to the TabletComputeNodeMapper. 
2. Add visibility for distribution of tablets to CN so we can easily see when tablets are unevenly distributed to CN. This expands on `SHOW PROC '/compute_nodes'` and `SHOW COMPUTE NODES`
3. Add visibility to which tablet is being most often scanned and which CN is meant to own it (and be primary backup) with new `SHOW PROC '/tablet_mapping'`

Note for the observability added: it's all in FE memory, so it's dis-aggregated and the lifecycle of the data is tied to the lifecycle of the FE. If we end up needing to consult this information regularly and decide that this level of accuracy isn't sufficient, then we might need to think about changes. But instead of framing this as "knowing which CN owns each tablet" we should think of it as "is the internal management of tablet->CN mapping working sufficiently well right now" and "is this CN really hot because it's handling too many tablets or because some tablet is really hot right now"?

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
