### PR TITLE
[BugFix] Cherry pick - fix incorrect materialized view row count (#51944)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
@@ -39,6 +39,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.common.Config;
+import com.starrocks.common.Pair;
 import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
@@ -116,7 +117,7 @@ public class TabletStatMgr extends FrontendDaemon {
 
                 // NOTE: calculate the row first with read lock, then update the stats with write lock
                 locker.lockTableWithIntensiveDbLock(db, table.getId(), LockType.READ);
-                Map<Long, Long> indexRowCountMap = Maps.newHashMap();
+                Map<Pair<Long, Long>, Long> indexRowCountMap = Maps.newHashMap();
                 try {
                     OlapTable olapTable = (OlapTable) table;
                     for (Partition partition : olapTable.getAllPartitions()) {
@@ -129,7 +130,8 @@ public class TabletStatMgr extends FrontendDaemon {
                                 for (Tablet tablet : index.getTablets()) {
                                     indexRowCount += tablet.getRowCount(version);
                                 } // end for tablets
-                                indexRowCountMap.put(index.getId(), indexRowCount);
+                                indexRowCountMap.put(Pair.create(physicalPartition.getId(), index.getId()),
+                                        indexRowCount);
                                 if (!olapTable.isTempPartition(partition.getId())) {
                                     totalRowCount += indexRowCount;
                                 }
@@ -150,7 +152,8 @@ public class TabletStatMgr extends FrontendDaemon {
                         for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
                             for (MaterializedIndex index :
                                     physicalPartition.getMaterializedIndices(IndexExtState.VISIBLE)) {
-                                Long indexRowCount = indexRowCountMap.get(index.getId());
+                                Long indexRowCount =
+                                        indexRowCountMap.get(Pair.create(physicalPartition.getId(), index.getId()));
                                 if (indexRowCount != null) {
                                     index.setRowCount(indexRowCount);
                                 }


### PR DESCRIPTION
## Why I'm doing:
This bug was discovered internally when a version upgrade from 3.1.4 to 3.3.4 caused performance to worsen despite queries and the data in underlying tables to remain the same. Running explain costs against the query in 3.3.4 revealed an incorrect cardinality of 1 for the OLAP scan node in the query plan. This incorrect cardinality value caused the query planner to take a non-optimal approach towards executing the query in concern. As such this fix is aimed at ultimatley correcting query performance but more specifically fixing row count estimation. 

## What I'm doing:
Cherry picking https://github.com/StarRocks/starrocks/pull/52018. There is one change made on top of a pure cherry pick which is not eliminating the lockTableWithIntensiveDbLock call prior to calculating row counts. This lock was reintroduced here - https://github.com/StarRocks/starrocks/commit/7402d0eebbba6430c34af504e5a37fdf388acc45. 

## How I tested:
Running a build with the latest commit of the [pinterest-integration-3.3](https://github.com/pinterest/starrocks/tree/pinterest-integration-3.3) branch, I reproduced the cardinality bug by ingesting into a table and checking the cardinality prior to running analysis. I then deployed a build containing this fix and verified that cardinality estimation was in-line with reasonable values.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0