### PR TITLE
Emit metrics related to how many tablets are owned by a CN

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
@@ -41,8 +41,6 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.system.TabletComputeNodeMapper;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -55,8 +53,6 @@ import java.util.TimerTask;
  * such QPS, and save the result for users to get.
  */
 public class MetricCalculator extends TimerTask {
-    private static final Logger LOG = LogManager.getLogger(MetricCalculator.class);
-
     private long lastTs = -1;
     private long lastQueryCounter = -1;
     private long lastRequestCounter = -1;

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
@@ -39,10 +39,15 @@ import com.starrocks.qe.QueryDetail;
 import com.starrocks.qe.QueryDetailQueue;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
+import com.starrocks.system.SystemInfoService;
+import com.starrocks.system.TabletComputeNodeMapper;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.TimerTask;
 
 /*
@@ -50,11 +55,14 @@ import java.util.TimerTask;
  * such QPS, and save the result for users to get.
  */
 public class MetricCalculator extends TimerTask {
+    private static final Logger LOG = LogManager.getLogger(MetricCalculator.class);
+
     private long lastTs = -1;
     private long lastQueryCounter = -1;
     private long lastRequestCounter = -1;
     private long lastQueryErrCounter = -1;
     private long lastQueryEventTime = -1;
+    private long lastTabletMappingTs = -1;
 
     @Override
     public void run() {
@@ -158,5 +166,34 @@ public class MetricCalculator extends TimerTask {
         }
 
         MetricRepo.GAUGE_SAFE_MODE.setValue(GlobalStateMgr.getCurrentState().isSafeMode() ? 1 : 0);
+
+        // Update the count of tablets owned by each CN and times a CN was used for a scan
+        // update the owned tablet counts less often because it's expensive to calculate and doesn't change frequently.
+        long timeSinceLastTabletMappingUpdate = (currentTs - lastTabletMappingTs) / 1000 + 1;
+        if (RunMode.isSharedDataMode() && timeSinceLastTabletMappingUpdate >= 60) {
+            lastTabletMappingTs = currentTs;
+            final SystemInfoService clusterInfoService = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+            boolean usingInternalMapper = clusterInfoService.shouldUseInternalTabletToCnMapper();
+            // We don't have a way of easily assessing which CN owns which tablets if we're not using our internal mapper.
+            if (usingInternalMapper) {
+                TabletComputeNodeMapper mapper =  clusterInfoService.internalTabletMapper();
+                Map<Long, Long> computeNodeToOwnedTabletCount = mapper.computeNodeToOwnedTabletCount();
+                // Note that this will only return information about tablets which this FE has needed to scan.
+                for (Map.Entry<Long, Long> pair : computeNodeToOwnedTabletCount.entrySet()) {
+                    String cnId = String.valueOf(pair.getKey());
+                    long ownedTabletCount = pair.getValue();
+                    if (ownedTabletCount <= 0) {
+                        // For CN in different resource isolation groups from this FE, this FE won't have information about owned
+                        // tablet counts. Rather than report useless information, we skip this.
+                        continue;
+                    }
+                    MetricRepo.GAUGE_CN_TO_OWNED_TABLET_COUNT.getMetric(cnId).setValue(ownedTabletCount);
+
+                    LongCounterMetric m = MetricRepo.COUNTER_CN_SELECTED_FOR_TABLET_SCAN.getMetric(cnId);
+                    Long newSelectCount = mapper.getComputeNodeReturnCount(pair.getKey());
+                    m.increase(newSelectCount - m.getValue());
+                }
+            }
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -141,6 +141,16 @@ public final class MetricRepo {
                     () -> new LongCounterMetric("query_queue_v2_category_state", MetricUnit.REQUESTS,
                             "the current state of each category"));
 
+    public static final MetricWithLabelGroup<LongCounterMetric> COUNTER_CN_SELECTED_FOR_TABLET_SCAN =
+            new MetricWithLabelGroup<>("cn_id",
+                    () -> new LongCounterMetric("cn_selected_for_tablet_scan", MetricUnit.NOUNIT,
+                            "times this FE selected the given CN for a scan of some tablet"));
+    public static final MetricWithLabelGroup<GaugeMetricImpl<Long>> GAUGE_CN_TO_OWNED_TABLET_COUNT =
+            new MetricWithLabelGroup<>("cn_id",
+                    () -> new GaugeMetricImpl<>("cn_to_owned_tablet_count", MetricUnit.NOUNIT,
+                            "Number of tablets for which the cn is primarily responsible " +
+                                    "(only populated appropriately for CN in the same Resource isolation group as this FE)"));
+
     public static LongCounterMetric COUNTER_UNFINISHED_BACKUP_JOB;
     public static LongCounterMetric COUNTER_UNFINISHED_RESTORE_JOB;
 

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricWithLabelGroup.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricWithLabelGroup.java
@@ -16,6 +16,7 @@ package com.starrocks.metric;
 
 import com.google.common.collect.Maps;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -38,4 +39,9 @@ public class MetricWithLabelGroup<E extends Metric<?>> {
             return metric;
         });
     }
+
+    public Collection<E> getAllMetrics() {
+        return labelValueToMetric.values();
+    }
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricWithLabelGroup.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricWithLabelGroup.java
@@ -16,7 +16,6 @@ package com.starrocks.metric;
 
 import com.google.common.collect.Maps;
 
-import java.util.Collection;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -39,9 +38,4 @@ public class MetricWithLabelGroup<E extends Metric<?>> {
             return metric;
         });
     }
-
-    public Collection<E> getAllMetrics() {
-        return labelValueToMetric.values();
-    }
-
 }

--- a/fe/fe-core/src/main/java/com/starrocks/system/TabletComputeNodeMapper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/TabletComputeNodeMapper.java
@@ -240,9 +240,10 @@ public class TabletComputeNodeMapper {
         return tabletMappingCount;
     }
 
-    // Key is compute node id. Value is number of distinct tablets for which this mapper instance has returned the given CN.
+    // Key is compute node id. Value is number of distinct tablets for which this mapper instance will currently assign primary
+    // ownership to the given CN.
     // Note, this is a kind of best-effort count -- it is possible that the given CN "owns" many more tablets, but we simply
-    // haven't scanned them due to a query that has been issued to this FE since this mapper has been instantiated.
+    // haven't scanned some of those tablets since this mapper has been instantiated (when this FE came up).
     // Note: this function is kind of expensive (~1 ms for largish databases), don't call it often.
     public Map<Long, Long> computeNodeToOwnedTabletCount() throws IllegalStateException {
         long startTime = System.currentTimeMillis();


### PR DESCRIPTION
## Why I'm doing:
Want to emit these to dashboards so we can be relatively sure that tablets are well balanced across CN and no CN is too hot based on load assigned. 
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0