### PR TITLE
patch bug fix for hll syntax error thrown on leader

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -233,6 +233,7 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         this.columnId = column.getColumnId();
         this.type = column.type;
         this.type.setAggStateDesc(column.aggStateDesc);
+        this.aggStateDesc = column.aggStateDesc;
         this.aggregationType = column.getAggregationType();
         this.isAggregationTypeImplicit = column.isAggregationTypeImplicit();
         this.isKey = column.isKey();


### PR DESCRIPTION
## Why I'm doing:
Without this, the followers/observers can execute a query just fine but the leader actually spits out a syntax error
follower
```
mysql> SELECT
    ->   __time,
    ->   ds_hll_count_distinct_merge(TOTAL_IMPRESSION_USER) as TOTAL_IMPRESSION_USER
    -> FROM  (
    -> SELECT
    ->   date_trunc('day', __time) as __time,
    ->   ds_hll_count_distinct_union(case when action_actiontype = 4 then cnt_unique else null end) as TOTAL_IMPRESSION_USER
    -> FROM
    -> test.ads_metrics_onsite_realtime_staging WHERE insertion_candidate_gadvertiserid = 549757815131 AND  __time >= '2025-03-07 00:00:00.000' and __time <= '2025-03-10 00:00:00.000' and insertion_candidate_domain_pos = 0
    -> GROUP BY __time
    -> UNION
    -> SELECT
    ->   date_trunc('day', __time) as __time,
    ->   ds_hll_count_distinct_union(case when action_actiontype = 4 then cnt_unique else null end) as TOTAL_IMPRESSION_USER
    -> FROM
    -> test.ads_metrics_onsite_batch_daily_uniques_staging WHERE insertion_candidate_gadvertiserid = 549757815131 AND  __time >= '2025-03-01 00:00:00.000' and __time <= '2025-03-05 00:00:00.000' and insertion_candidate_domain_pos = 0
    -> GROUP BY __time) A
    -> GROUP BY __time
    -> ORDER BY __TIME DESC
    -> LIMIT 10;
+---------------------+-----------------------+
| __time              | TOTAL_IMPRESSION_USER |
+---------------------+-----------------------+
| 2025-03-07 00:00:00 |                 19772 |
| 2025-03-05 00:00:00 |                 42304 |
| 2025-03-04 00:00:00 |                 45571 |
| 2025-03-03 00:00:00 |                 41981 |
| 2025-03-02 00:00:00 |                 37252 |
| 2025-03-01 00:00:00 |                 36024 |
+---------------------+-----------------------+
6 rows in set (2.13 sec)
leader:
mysql> SELECT
    ->   __time,
    ->   ds_hll_count_distinct_merge(TOTAL_IMPRESSION_USER) as TOTAL_IMPRESSION_USER
    -> FROM  (
    -> SELECT
    ->   date_trunc('day', __time) as __time,
    ->   ds_hll_count_distinct_union(case when action_actiontype = 4 then cnt_unique else null end) as TOTAL_IMPRESSION_USER
    -> FROM
    -> test.ads_metrics_onsite_realtime_staging WHERE insertion_candidate_gadvertiserid = 549757815131 AND  __time >= '2025-03-07 00:00:00.000' and __time <= '2025-03-10 00:00:00.000' and insertion_candidate_domain_pos = 0
    -> GROUP BY __time
    -> UNION
    -> SELECT
    ->   date_trunc('day', __time) as __time,
    ->   ds_hll_count_distinct_union(case when action_actiontype = 4 then cnt_unique else null end) as TOTAL_IMPRESSION_USER
    -> FROM
    -> test.ads_metrics_onsite_batch_daily_uniques_staging WHERE insertion_candidate_gadvertiserid = 549757815131 AND  __time >= '2025-03-01 00:00:00.000' and __time <= '2025-03-05 00:00:00.000' and insertion_candidate_domain_pos = 0
    -> GROUP BY __time) A
    -> GROUP BY __time
    -> ORDER BY __TIME DESC
    -> LIMIT 10;
ERROR 1064 (HY000): Getting analyzing error from line 7, column 2 to line 7, column 91. Detail message: AggState's AggFunc should have AggStateDesc: ds_hll_count_distinct_union(varbinary).
```

## What I'm doing:
`git cherry-pick 995b404c59ad7065e01a6059dca37e42701a6d46`
from https://github.com/StarRocks/starrocks/pull/52654
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0