### PR TITLE
HLL Apache Datasketches - Alignment with Spark generated HLL hash values 

### DIFF
--- a/be/src/types/hll_sketch.cpp
+++ b/be/src/types/hll_sketch.cpp
@@ -44,8 +44,14 @@ bool DataSketchesHll::is_valid(const Slice& slice) {
     }
 }
 
+// no longer used since we no longer take the murmur hash value as input to the hll sketch
 void DataSketchesHll::update(uint64_t hash_value) {
     _sketch_union->update(hash_value);
+    this->mark_changed();
+}
+
+void DataSketchesHll::update(const void* data, size_t length_bytes) {
+    _sketch_union->update(data, length_bytes);
     this->mark_changed();
 }
 

--- a/be/src/types/hll_sketch.h
+++ b/be/src/types/hll_sketch.h
@@ -84,6 +84,10 @@ public:
     // NOTE: input must be a hash_value
     void update(uint64_t hash_value);
 
+    // Add a byte array to this HLL value
+    // NOTE: input must be a byte array
+    void update(const void* data, size_t length_bytes);
+
     // merge with other HLL value
     void merge(const DataSketchesHll& other);
 


### PR DESCRIPTION
## Why I'm doing:
Today, Spark's hll_sketch_agg function passes in the raw data values to the HLL sketch update function. Whereas StarRocks takes a murmur hash of the raw data values prior to passing values into the HLL sketch update function. (https://github.com/apache/spark/blob/0670e4f7945ae4935261ed1f45db7ede79aca127/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/datasketchesAggregates.scala#L137)

The discrepancy above means that HLL hashes generated by StarRocks are not portable to Spark and vice versa.

## What I'm doing:
I am removing the murmur hash and instead passing byte arrays (raw values) into the HLL sketch update function. 
Note that this change is not backwards compatible in that HLL hashes that have already been generated would have been generated against the murmur hashed values instead of the raw data values.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0