### PR TITLE
Add dynamic config for Cauthz fail open/close

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1836,6 +1836,12 @@ public class Config extends ConfigBase {
     public static String cauthz_authorization_class_name = "";
 
     /**
+     * Whether CauthzAuthorizer for access control should fail open
+     */
+    @ConfField(mutable = true)
+    public static String cauthz_fail_open = false;
+
+    /**
      * The authentication_chain configuration specifies the sequence of security integrations
      * that will be used to authenticate a user. Each security integration in the chain will be
      * tried in the order they are defined until one of them successfully authenticates the user.

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1839,7 +1839,7 @@ public class Config extends ConfigBase {
      * Whether CauthzAuthorizer for access control should fail open
      */
     @ConfField(mutable = true)
-    public static String cauthz_fail_open = false;
+    public static boolean cauthz_fail_open = false;
 
     /**
      * The authentication_chain configuration specifies the sequence of security integrations


### PR DESCRIPTION
## Why I'm doing:
Add a dynamic fe config that determines if the cauthz call will be fail open or close. This should be dynamic in the case that an rta team member would like to make a change during an incident, etc.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0