### PR TITLE
cherry-pick cauthz fail open config

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1797,7 +1797,7 @@ public class Config extends ConfigBase {
      * Whether CauthzAuthorizer for access control should fail open
      */
     @ConfField(mutable = true)
-    public static String cauthz_fail_open = false;
+    public static boolean cauthz_fail_open = false;
 
     /**
      * The authentication_chain configuration specifies the sequence of security integrations

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1794,6 +1794,12 @@ public class Config extends ConfigBase {
     public static String cauthz_authorization_class_name = "";
 
     /**
+     * Whether CauthzAuthorizer for access control should fail open
+     */
+    @ConfField(mutable = true)
+    public static String cauthz_fail_open = false;
+
+    /**
      * The authentication_chain configuration specifies the sequence of security integrations
      * that will be used to authenticate a user. Each security integration in the chain will be
      * tried in the order they are defined until one of them successfully authenticates the user.


### PR DESCRIPTION
## Why I'm doing:
Need fail-open config in 3.3 version
## What I'm doing:
Cherry-pick of commits from https://github.com/pinterest/starrocks/pull/39 


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0