### PR TITLE
Cauthz: add fail open policy counter

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -171,6 +171,7 @@ public final class MetricRepo {
     public static LongCounterMetric COUNTER_ROUTINE_LOAD_PAUSED;
     public static LongCounterMetric COUNTER_SHORTCIRCUIT_QUERY;
     public static LongCounterMetric COUNTER_SHORTCIRCUIT_RPC;
+    public static LongCounterMetric COUNTER_FAIl_OPEN_POLICY_USED;
 
     public static Histogram HISTO_QUERY_LATENCY;
     public static Histogram HISTO_EDIT_LOG_WRITE_LATENCY;
@@ -460,11 +461,13 @@ public final class MetricRepo {
         STARROCKS_METRIC_REGISTER.addMetric(COUNTER_SHORTCIRCUIT_QUERY);
         COUNTER_SHORTCIRCUIT_RPC = new LongCounterMetric("shortcircuit_rpc", MetricUnit.REQUESTS, "total shortcircuit rpc");
         STARROCKS_METRIC_REGISTER.addMetric(COUNTER_SHORTCIRCUIT_RPC);
+        COUNTER_FAIl_OPEN_POLICY_USED = new LongCounterMetric("failopen_policy_used", MetricUnit.REQUESTS, "times fail-open policy used for cauthz");
+        STARROCKS_METRIC_REGISTER.addMetric(COUNTER_FAIl_OPEN_POLICY_USED);
 
         COUNTER_QUERY_ANALYSIS_ERR = new LongCounterMetric("query_analysis_err", MetricUnit.REQUESTS,
                                                            "total analysis error query");
         STARROCKS_METRIC_REGISTER.addMetric(COUNTER_QUERY_ANALYSIS_ERR);
-        COUNTER_QUERY_INTERNAL_ERR = new LongCounterMetric("query_internal_err", MetricUnit.REQUESTS, 
+        COUNTER_QUERY_INTERNAL_ERR = new LongCounterMetric("query_internal_err", MetricUnit.REQUESTS,
                                                            "total internal error query");
         STARROCKS_METRIC_REGISTER.addMetric(COUNTER_QUERY_INTERNAL_ERR);
 

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -171,7 +171,7 @@ public final class MetricRepo {
     public static LongCounterMetric COUNTER_ROUTINE_LOAD_PAUSED;
     public static LongCounterMetric COUNTER_SHORTCIRCUIT_QUERY;
     public static LongCounterMetric COUNTER_SHORTCIRCUIT_RPC;
-    public static LongCounterMetric COUNTER_FAIl_OPEN_POLICY_USED;
+    public static LongCounterMetric COUNTER_FAIL_OPEN_POLICY_USED;
 
     public static Histogram HISTO_QUERY_LATENCY;
     public static Histogram HISTO_EDIT_LOG_WRITE_LATENCY;
@@ -461,8 +461,8 @@ public final class MetricRepo {
         STARROCKS_METRIC_REGISTER.addMetric(COUNTER_SHORTCIRCUIT_QUERY);
         COUNTER_SHORTCIRCUIT_RPC = new LongCounterMetric("shortcircuit_rpc", MetricUnit.REQUESTS, "total shortcircuit rpc");
         STARROCKS_METRIC_REGISTER.addMetric(COUNTER_SHORTCIRCUIT_RPC);
-        COUNTER_FAIl_OPEN_POLICY_USED = new LongCounterMetric("failopen_policy_used", MetricUnit.REQUESTS, "times fail-open policy used for cauthz");
-        STARROCKS_METRIC_REGISTER.addMetric(COUNTER_FAIl_OPEN_POLICY_USED);
+        COUNTER_FAIL_OPEN_POLICY_USED = new LongCounterMetric("failopen_policy_used", MetricUnit.REQUESTS, "times fail-open policy used for cauthz");
+        STARROCKS_METRIC_REGISTER.addMetric(COUNTER_FAIL_OPEN_POLICY_USED);
 
         COUNTER_QUERY_ANALYSIS_ERR = new LongCounterMetric("query_analysis_err", MetricUnit.REQUESTS,
                                                            "total analysis error query");

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShortCircuitHybridExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShortCircuitHybridExecutor.java
@@ -287,8 +287,4 @@ public class ShortCircuitHybridExecutor extends ShortCircuitExecutor {
         });
     }
 
-    public void incFailOpenPolicyUsed(Long count) {
-        MetricRepo.COUNTER_FAIl_OPEN_POLICY_USED.increase(count);
-    }
-
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShortCircuitHybridExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShortCircuitHybridExecutor.java
@@ -287,4 +287,8 @@ public class ShortCircuitHybridExecutor extends ShortCircuitExecutor {
         });
     }
 
+    public void incFailOpenPolicyUsed(Long count) {
+        MetricRepo.COUNTER_FAIl_OPEN_POLICY_USED.increase(count);
+    }
+
 }


### PR DESCRIPTION
## Why I'm doing:

Need to be able to set up monitoring + alerting on when we're using fail-open policy for cauthz. 

## What I'm doing:

Added a new counter. This counter will be incremented by the internal class, which will get a follow-up PR. 

Fixes #issue

https://jira.pinadmin.com/browse/RTA-7598

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0