### PR TITLE
Revert "HTTP early disconnection fix"

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpResultSender.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpResultSender.java
@@ -70,15 +70,24 @@ public class HttpResultSender {
     public RowBatch sendQueryResult(Coordinator coord, ExecPlan execPlan, String sql) throws Exception {
         RowBatch batch;
         ChannelHandlerContext nettyChannel = context.getNettyChannel();
+        // if some data already sent to client, when exception occurs,we just close the channel
+        context.setSendDate(true);
+        sendHeader(nettyChannel);
+        // write connectId
+        if (!context.isOnlyOutputResultRaw()) {
+            nettyChannel.write(JsonSerializer.getConnectId(context.getConnectionId()));
+        }
+        // write column meta data
+        ByteBuf metaData = JsonSerializer.getMetaData(execPlan.getColNames(), execPlan.getOutputExprs());
+        nettyChannel.writeAndFlush(metaData);
+
         while (true) {
             batch = coord.getNext();
             if (batch.getBatch() != null) {
-                sendHeaderAndMetaData(nettyChannel, execPlan);
                 writeResultBatch(batch.getBatch(), nettyChannel, coord, sql);
                 context.updateReturnRows(batch.getBatch().getRows().size());
             }
             if (batch.isEos()) {
-                sendHeaderAndMetaData(nettyChannel, execPlan);
                 if (!context.isOnlyOutputResultRaw()) {
                     ByteBuf statisticData = JsonSerializer.getStatistic(batch.getQueryStatistics());
                     nettyChannel.writeAndFlush(statisticData);
@@ -164,18 +173,4 @@ public class HttpResultSender {
         }
     }
 
-    private void sendHeaderAndMetaData(ChannelHandlerContext nettyChannel, ExecPlan execPlan) throws IOException {
-        // if some data already sent to client, when exception occurs,we just close the channel
-        if (!context.getSendDate()) {
-            context.setSendDate(true);
-            sendHeader(nettyChannel);
-            // write connectId
-            if (!context.isOnlyOutputResultRaw()) {
-                nettyChannel.write(JsonSerializer.getConnectId(context.getConnectionId()));
-            }
-            // write column meta data
-            ByteBuf metaData = JsonSerializer.getMetaData(execPlan.getColNames(), execPlan.getOutputExprs());
-            nettyChannel.writeAndFlush(metaData);
-        }
-    }
 }


### PR DESCRIPTION
Reverts pinterest/starrocks#46

Causes client side latency to go up and QPS to plateau at a low value. Believe this is because the client blocks and fills up connection pool waiting for initial http response with header. 