### PR TITLE
Fix Starrocks's accessType to remove spaces

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/privilege/cauthz/starrocks/CauthzStarRocksAccessController.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/cauthz/starrocks/CauthzStarRocksAccessController.java
@@ -422,7 +422,12 @@ public class CauthzStarRocksAccessController extends CauthzAccessController {
 
     @Override
     public String convertToAccessType(PrivilegeType privilegeType) {
-        return privilegeType.name().toLowerCase(ENGLISH);
+        return normalizePrivilegeName(privilegeType);
+    }
+
+    public static String normalizePrivilegeName(PrivilegeType privilegeType) {
+        // Converts the enum value (e.g. CREATE_TABLE or CREATE TABLE) to lower_snake_case
+        return privilegeType.name().replaceAll("\\s+", "_").toLowerCase(ENGLISH);
     }
 }
 


### PR DESCRIPTION
## Why I'm doing:
The cauthz schema expects "create_table" and "create_view", not "create table" and "create view"

Turns 
```
curl -i -H "Content-Type: application/json" -X POST localhost:18181/cauthz/ -d '{"input":{"resource":{"id":"starrocks-dev5_test","type":"starrocks/database"},"subject":{"id":"cbrennan","type":"ldap_user"},"permission":"create table"}}'
```

into 
```
curl -i -H "Content-Type: application/json" -X POST localhost:18181/cauthz/ -d '{"input":{"resource":{"id":"starrocks-dev5_test","type":"starrocks/database"},"subject":{"id":"cbrennan","type":"ldap_user"},"permission":"create_table"}}'

```
## What I'm doing:
1. Replacing spaces with underscores. 
2. Making it public so it can be shared with internal authorizer class

Fixes #issue

https://jira.pinadmin.com/browse/RTA-7691

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0