### PR TITLE
Cherrypick: Fast schema evolution support for adding key columns in shared-data mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeData.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeData.java
@@ -41,6 +41,7 @@ class SchemaChangeData {
     private final double bloomFilterFpp;
     private final boolean hasIndexChanged;
     private final Map<Long, Short> newIndexShortKeyCount;
+    private final boolean shortKeyChanged;
     private final List<Integer> sortKeyIdxes;
     private final List<Integer> sortKeyUniqueIds;
     private final long warehouseId;
@@ -96,6 +97,10 @@ class SchemaChangeData {
         return Collections.unmodifiableMap(newIndexShortKeyCount);
     }
 
+    boolean isShortKeyChanged() {
+        return shortKeyChanged;
+    }
+
     @Nullable
     List<Integer> getSortKeyIdxes() {
         return sortKeyIdxes;
@@ -121,6 +126,7 @@ class SchemaChangeData {
         this.bloomFilterFpp = builder.bloomFilterFpp;
         this.hasIndexChanged = builder.hasIndexChanged;
         this.newIndexShortKeyCount = Objects.requireNonNull(builder.newIndexShortKeyCount, "newIndexShortKeyCount is null");
+        this.shortKeyChanged = builder.shortKeyChanged;
         this.sortKeyIdxes = builder.sortKeyIdxes;
         this.sortKeyUniqueIds = builder.sortKeyUniqueIds;
         this.warehouseId = builder.warehouseId;
@@ -137,6 +143,7 @@ class SchemaChangeData {
         private double bloomFilterFpp;
         private boolean hasIndexChanged = false;
         private Map<Long, Short> newIndexShortKeyCount = new HashMap<>();
+        private boolean shortKeyChanged = false;
         private List<Integer> sortKeyIdxes;
         private List<Integer> sortKeyUniqueIds;
         private long warehouseId;
@@ -176,8 +183,9 @@ class SchemaChangeData {
             return this;
         }
 
-        Builder withNewIndexShortKeyCount(long indexId, short shortKeyCount) {
+        Builder withNewIndexShortKeyCount(long indexId, short shortKeyCount, boolean shortKeyChanged) {
             this.newIndexShortKeyCount.put(indexId, shortKeyCount);
+            this.shortKeyChanged |= shortKeyChanged;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1098,11 +1098,6 @@ public class SchemaChangeHandler extends AlterHandler {
             throw new DdlException("PERCENTILE_UNION must be used in AGG_KEYS");
         }
 
-        //type key column do not allow light schema change.
-        if (newColumn.isKey()) {
-            fastSchemaEvolution = false;
-        }
-
         // check if the new column already exist in base schema.
         // do not support adding new column which already exist in base schema.
         Optional<Column> foundColumn = olapTable.getBaseSchema().stream()
@@ -1110,6 +1105,11 @@ public class SchemaChangeHandler extends AlterHandler {
         if (foundColumn.isPresent() && newColumn.equals(foundColumn.get())) {
             throw new DdlException(
                     "Can not add column which already exists in base table: " + newColName);
+        }
+
+        // TODO shared-nothing needs to modify codes on BE side, and will support fast schema evolution later
+        if (newColumn.isKey() && RunMode.isSharedNothingMode()) {
+            fastSchemaEvolution = false;
         }
 
         // check if the new column already exist in column id.
@@ -1449,7 +1449,6 @@ public class SchemaChangeHandler extends AlterHandler {
             dataBuilder.withWarehouse(warehouseId);
         }
 
-        long baseIndexId = olapTable.getBaseIndexId();
         Map<Integer, Column> columnUniqueIdToColumn = Maps.newHashMap();
         // begin checking each table
         // ATTN: DO NOT change any meta in this loop
@@ -1533,46 +1532,7 @@ public class SchemaChangeHandler extends AlterHandler {
             checkDistributionColumnChange(olapTable, alterSchema, alterIndexId);
 
             // 5. calc short key
-            List<Integer> sortKeyIdxes = new ArrayList<>();
-            List<Integer> sortKeyUniqueIds = new ArrayList<>();
-            MaterializedIndexMeta index = olapTable.getIndexMetaByIndexId(alterIndexId);
-            // if sortKeyUniqueIds is empty, the table maybe create in old version and we should use sortKeyIdxes
-            // to determine which columns are sort key columns
-            boolean useSortKeyUniqueId = (index.getSortKeyUniqueIds() != null) &&
-                    (!index.getSortKeyUniqueIds().isEmpty());
-            if (index.getSortKeyIdxes() != null && baseIndexId == alterIndexId) {
-                List<Integer> originSortKeyIdxes = index.getSortKeyIdxes();
-                for (Integer colIdx : originSortKeyIdxes) {
-                    String columnName = index.getSchema().get(colIdx).getName();
-                    Optional<Column> oneCol =
-                            alterSchema.stream().filter(c -> c.nameEquals(columnName, true)).findFirst();
-                    if (oneCol.isEmpty()) {
-                        LOG.warn("Sort Key Column[" + columnName + "] not exists in new schema");
-                        throw new DdlException("Sort Key Column[" + columnName + "] not exists in new schema");
-                    }
-                    int sortKeyIdx = alterSchema.indexOf(oneCol.get());
-                    sortKeyIdxes.add(sortKeyIdx);
-                    if (useSortKeyUniqueId) {
-                        sortKeyUniqueIds.add(alterSchema.get(sortKeyIdx).getUniqueId());
-                    }
-                }
-            }
-            if (!sortKeyIdxes.isEmpty()) {
-                short newShortKeyCount = GlobalStateMgr.calcShortKeyColumnCount(alterSchema,
-                        indexIdToProperties.get(alterIndexId),
-                        sortKeyIdxes);
-                LOG.debug("alter index[{}] short key column count: {}", alterIndexId, newShortKeyCount);
-                dataBuilder.withNewIndexShortKeyCount(alterIndexId,
-                        newShortKeyCount).withNewIndexSchema(alterIndexId, alterSchema);
-                dataBuilder.withSortKeyIdxes(sortKeyIdxes);
-                dataBuilder.withSortKeyUniqueIds(sortKeyUniqueIds);
-            } else {
-                short newShortKeyCount = GlobalStateMgr.calcShortKeyColumnCount(alterSchema,
-                        indexIdToProperties.get(alterIndexId));
-                LOG.debug("alter index[{}] short key column count: {}", alterIndexId, newShortKeyCount);
-                dataBuilder.withNewIndexShortKeyCount(alterIndexId,
-                        newShortKeyCount).withNewIndexSchema(alterIndexId, alterSchema);
-            }
+            calculateShortKey(olapTable, alterIndexId, alterSchema, indexIdToProperties.get(alterIndexId), dataBuilder);
 
             // 6. check the uniqueness of column unique id
             if (olapTable.getMaxColUniqueId() > Column.COLUMN_UNIQUE_ID_INIT_VALUE) {
@@ -1591,6 +1551,122 @@ public class SchemaChangeHandler extends AlterHandler {
         } // end for indices
 
         return dataBuilder.build();
+    }
+
+    private void calculateShortKey(OlapTable olapTable, long alterIndexId, List<Column> alterSchema,
+               Map<String, String> indexProperties, SchemaChangeData.Builder dataBuilder) throws DdlException {
+        List<Integer> sortKeyIdxes = new ArrayList<>();
+        List<Integer> sortKeyUniqueIds = new ArrayList<>();
+        MaterializedIndexMeta index = olapTable.getIndexMetaByIndexId(alterIndexId);
+        List<Column> originSchema = index.getSchema();
+        // if sortKeyUniqueIds is empty, the table maybe create in old version and we should use sortKeyIdxes
+        // to determine which columns are sort key columns
+        boolean useSortKeyUniqueId = (index.getSortKeyUniqueIds() != null) &&
+                (!index.getSortKeyUniqueIds().isEmpty());
+        if (index.getSortKeyIdxes() != null && olapTable.getBaseIndexId() == alterIndexId) {
+            List<Integer> originSortKeyIdxes = index.getSortKeyIdxes();
+            for (Integer colIdx : originSortKeyIdxes) {
+                String columnName = originSchema.get(colIdx).getName();
+                Optional<Column> oneCol =
+                        alterSchema.stream().filter(c -> c.nameEquals(columnName, true)).findFirst();
+                if (oneCol.isEmpty()) {
+                    LOG.warn("Sort Key Column[" + columnName + "] not exists in new schema");
+                    throw new DdlException("Sort Key Column[" + columnName + "] not exists in new schema");
+                }
+                int sortKeyIdx = alterSchema.indexOf(oneCol.get());
+                sortKeyIdxes.add(sortKeyIdx);
+                if (useSortKeyUniqueId) {
+                    sortKeyUniqueIds.add(alterSchema.get(sortKeyIdx).getUniqueId());
+                }
+            }
+        }
+
+        if (!sortKeyIdxes.isEmpty()) {
+            short newShortKeyCount = GlobalStateMgr.calcShortKeyColumnCount(alterSchema,
+                    indexProperties, sortKeyIdxes);
+            LOG.debug("alter index[{}] short key column count: {}", alterIndexId, newShortKeyCount);
+
+            List<Integer> originSortKeyIdxes = index.getSortKeyIdxes();
+            List<Column> originShortKeyColumns = new ArrayList<>();
+            for (int i = 0; i < index.getShortKeyColumnCount(); i++) {
+                originShortKeyColumns.add(originSchema.get(originSortKeyIdxes.get(i)));
+            }
+            List<Column> newShortKeyColumns = new ArrayList<>();
+            for (int i = 0; i < newShortKeyCount; i++) {
+                newShortKeyColumns.add(alterSchema.get(sortKeyIdxes.get(i)));
+            }
+            boolean isShortKeyChanged = isShortKeyChanged(originShortKeyColumns, newShortKeyColumns);
+            dataBuilder.withNewIndexShortKeyCount(alterIndexId,
+                    newShortKeyCount, isShortKeyChanged).withNewIndexSchema(alterIndexId, alterSchema);
+            dataBuilder.withSortKeyIdxes(sortKeyIdxes);
+            dataBuilder.withSortKeyUniqueIds(sortKeyUniqueIds);
+        } else {
+            short newShortKeyCount = GlobalStateMgr.calcShortKeyColumnCount(alterSchema, indexProperties);
+            LOG.debug("alter index[{}] short key column count: {}", alterIndexId, newShortKeyCount);
+            
+            List<Column> originShortKeyColumns = new ArrayList<>();
+            for (int i = 0; i < index.getShortKeyColumnCount(); i++) {
+                originShortKeyColumns.add(originSchema.get(i));
+            }
+            List<Column> newShortKeyColumns = new ArrayList<>();
+            for (int i = 0; i < newShortKeyCount; i++) {
+                newShortKeyColumns.add(alterSchema.get(i));
+            }
+            boolean isShortKeyChanged = isShortKeyChanged(originShortKeyColumns, newShortKeyColumns);
+            dataBuilder.withNewIndexShortKeyCount(alterIndexId,
+                    newShortKeyCount, isShortKeyChanged).withNewIndexSchema(alterIndexId, alterSchema);
+        }
+    }
+
+    private boolean isShortKeyChanged(List<Column> originShortKeyColumns, List<Column> newShortKeyColumns) {
+        if (originShortKeyColumns.size() != newShortKeyColumns.size()) {
+            return true;
+        }
+        for (int i = 0; i < originShortKeyColumns.size(); i++) {
+            Column originColumn = originShortKeyColumns.get(i);
+            Column newColumn = newShortKeyColumns.get(i);
+            if (!originColumn.getName().equalsIgnoreCase(newColumn.getName())
+                    || !originColumn.getType().equals(newColumn.getType())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected static Map<String, Column> buildSchemaMapFromList(List<Column> schema, boolean ignorePrefix,
+                                                                boolean caseSensibility) {
+        Map<String, Column> schemaMap = Maps.newHashMap();
+        if (ignorePrefix) {
+            if (caseSensibility) {
+                schema.forEach(col -> schemaMap.put(Column.removeNamePrefix(col.getName()), col));
+            } else {
+                schema.forEach(col -> schemaMap.put(Column.removeNamePrefix(col.getName()).toLowerCase(), col));
+            }
+        } else {
+            if (caseSensibility) {
+                schema.forEach(col -> schemaMap.put(col.getName(), col));
+            } else {
+                schema.forEach(col -> schemaMap.put(col.getName().toLowerCase(), col));
+            }
+        }
+        return schemaMap;
+    }
+
+    protected static Column getColumnFromSchemaMap(Map<String, Column> originSchemaMap, String col,
+                                                   boolean ignorePrefix, boolean caseSensibility) {
+        if (caseSensibility) {
+            if (ignorePrefix) {
+                return originSchemaMap.get(Column.removeNamePrefix(col));
+            } else {
+                return originSchemaMap.get(col);
+            }
+        } else {
+            if (ignorePrefix) {
+                return originSchemaMap.get(Column.removeNamePrefix(col).toLowerCase());
+            } else {
+                return originSchemaMap.get(col.toLowerCase());
+            }
+        }
     }
 
     private void checkPartitionColumnChange(OlapTable olapTable, List<Column> alterSchema, long alterIndexId)
@@ -1894,6 +1970,9 @@ public class SchemaChangeHandler extends AlterHandler {
 
         SchemaChangeData schemaChangeData = finalAnalyze(db, olapTable, indexSchemaMap, propertyMap, newIndexes,
                 modifyFieldColumns);
+        if (schemaChangeData.isShortKeyChanged()) {
+            fastSchemaEvolution = false;
+        }
 
         if (schemaChangeData.getNewIndexSchema().isEmpty() && !schemaChangeData.isHasIndexChanged()) {
             // Nothing changed.

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.alter;
 
+import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndexMeta;
@@ -24,6 +25,8 @@ import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.util.TimeUtils;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.lake.LakeTable;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
@@ -68,27 +71,23 @@ public class LakeTableAsyncFastSchemaChangeJobTest {
         GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(connectContext, stmt);
     }
 
-    private LakeTableAsyncFastSchemaChangeJob getAlterJob(Table table) {
+    private AlterJobV2 getAlterJob(Table table) {
         AlterJobMgr alterJobMgr = GlobalStateMgr.getCurrentState().getAlterJobMgr();
         List<AlterJobV2> jobs = alterJobMgr.getSchemaChangeHandler().getUnfinishedAlterJobV2ByTableId(table.getId());
-        Assert.assertEquals(1, jobs.size());
-        AlterJobV2 alterJob = jobs.get(0);
-        Assert.assertTrue(alterJob instanceof LakeTableAsyncFastSchemaChangeJob);
-        return (LakeTableAsyncFastSchemaChangeJob) alterJob;
+        Assertions.assertEquals(1, jobs.size());
+        return jobs.get(0);
     }
 
-    private LakeTableAsyncFastSchemaChangeJob removeAlterJob(Table table) {
-        LakeTableAsyncFastSchemaChangeJob job = getAlterJob(table);
-        AlterHandler handler = GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler();
-        handler.alterJobsV2.remove(job.getJobId());
-        return job;
-    }
-
-    private AlterJobV2 mustAlterTable(Table table, String sql) throws Exception {
+    private AlterJobV2 executeAlterAndWaitFinish(Table table, String sql, boolean expectFastSchemaEvolution) throws Exception {
         alterTable(connectContext, sql);
         AlterJobV2 alterJob = getAlterJob(table);
         alterJob.run();
-        Assert.assertEquals(AlterJobV2.JobState.FINISHED, alterJob.getJobState());
+        while (alterJob.getJobState() != AlterJobV2.JobState.FINISHED) {
+            alterJob.run();
+            Thread.sleep(100);
+        }
+        Assertions.assertEquals(AlterJobV2.JobState.FINISHED, alterJob.getJobState());
+        Assertions.assertEquals(expectFastSchemaEvolution, (alterJob instanceof LakeTableAsyncFastSchemaChangeJob));
         return alterJob;
     }
 
@@ -99,7 +98,7 @@ public class LakeTableAsyncFastSchemaChangeJobTest {
         long oldSchemaId = table.getIndexIdToMeta().get(table.getBaseIndexId()).getSchemaId();
 
         {
-            mustAlterTable(table, "ALTER TABLE t0 ADD COLUMN c1 BIGINT");
+            executeAlterAndWaitFinish(table, "ALTER TABLE t0 ADD COLUMN c1 BIGINT", true);
             List<Column> columns = table.getBaseSchema();
             Assert.assertEquals(2, columns.size());
             Assert.assertEquals("c0", columns.get(0).getName());
@@ -111,7 +110,7 @@ public class LakeTableAsyncFastSchemaChangeJobTest {
         }
         oldSchemaId = table.getIndexIdToMeta().get(table.getBaseIndexId()).getSchemaId();
         {
-            mustAlterTable(table, "ALTER TABLE t0 DROP COLUMN c1");
+            executeAlterAndWaitFinish(table, "ALTER TABLE t0 DROP COLUMN c1", true);
             List<Column> columns = table.getBaseSchema();
             Assert.assertEquals(1, columns.size());
             Assert.assertEquals("c0", columns.get(0).getName());
@@ -121,7 +120,7 @@ public class LakeTableAsyncFastSchemaChangeJobTest {
         }
         oldSchemaId = table.getIndexIdToMeta().get(table.getBaseIndexId()).getSchemaId();
         {
-            mustAlterTable(table, "ALTER TABLE t0 ADD COLUMN c1 BIGINT");
+            executeAlterAndWaitFinish(table, "ALTER TABLE t0 ADD COLUMN c1 BIGINT", true);
             List<Column> columns = table.getBaseSchema();
             Assert.assertEquals(2, columns.size());
             Assert.assertEquals("c0", columns.get(0).getName());
@@ -136,8 +135,8 @@ public class LakeTableAsyncFastSchemaChangeJobTest {
     @Test
     public void testGetInfo() throws Exception {
         LakeTable table = createTable(connectContext, "CREATE TABLE t1(c0 INT) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) " +
-                "BUCKETS 2 PROPERTIES('fast_schema_evolution'='true')");
-        AlterJobV2 job = mustAlterTable(table, "ALTER TABLE t1 ADD COLUMN c1 BIGINT");
+                    "BUCKETS 2 PROPERTIES('fast_schema_evolution'='true')");
+        AlterJobV2 job = executeAlterAndWaitFinish(table, "ALTER TABLE t1 ADD COLUMN c1 BIGINT", true);
         List<List<Comparable>> infoList = new ArrayList<>();
         job.getInfo(infoList);
         Assert.assertEquals(1, infoList.size());
@@ -213,7 +212,7 @@ public class LakeTableAsyncFastSchemaChangeJobTest {
         long oldSchemaId = table.getIndexIdToMeta().get(table.getBaseIndexId()).getSchemaId();
 
         {
-            mustAlterTable(table, "ALTER TABLE t_test_sort_key ADD COLUMN c2 BIGINT");
+            executeAlterAndWaitFinish(table, "ALTER TABLE t_test_sort_key ADD COLUMN c2 BIGINT", true);
             List<Column> columns = table.getBaseSchema();
             Assert.assertEquals(3, columns.size());
             Assert.assertEquals("c0", columns.get(0).getName());
@@ -227,7 +226,7 @@ public class LakeTableAsyncFastSchemaChangeJobTest {
         }
         oldSchemaId = table.getIndexIdToMeta().get(table.getBaseIndexId()).getSchemaId();
         {
-            mustAlterTable(table, "ALTER TABLE t_test_sort_key DROP COLUMN c2");
+            executeAlterAndWaitFinish(table, "ALTER TABLE t_test_sort_key DROP COLUMN c2", true);
             List<Column> columns = table.getBaseSchema();
             Assert.assertEquals(2, columns.size());
             Assert.assertEquals("c0", columns.get(0).getName());
@@ -246,7 +245,7 @@ public class LakeTableAsyncFastSchemaChangeJobTest {
         long oldSchemaId = table.getIndexIdToMeta().get(table.getBaseIndexId()).getSchemaId();
 
         {
-            mustAlterTable(table, "ALTER TABLE t_test_sort_key_index_changed DROP COLUMN c1");
+            executeAlterAndWaitFinish(table, "ALTER TABLE t_test_sort_key_index_changed DROP COLUMN c1", true);
             List<Column> columns = table.getBaseSchema();
             Assert.assertEquals(2, columns.size());
             Assert.assertEquals("c0", columns.get(0).getName());
@@ -268,8 +267,8 @@ public class LakeTableAsyncFastSchemaChangeJobTest {
                 "BUCKETS 1 PROPERTIES('fast_schema_evolution'='true')");
         long oldSchemaId = table.getIndexIdToMeta().get(table.getBaseIndexId()).getSchemaId();
         {
-            mustAlterTable(table, "ALTER TABLE t_modify_type MODIFY COLUMN c1 BIGINT, MODIFY COLUMN c2 VARCHAR(10)," +
-                    "MODIFY COLUMN c3 DATETIME");
+            executeAlterAndWaitFinish(table, "ALTER TABLE t_modify_type MODIFY COLUMN c1 BIGINT, MODIFY COLUMN c2 VARCHAR(10)," +
+                        "MODIFY COLUMN c3 DATETIME", true);
             List<Column> columns = table.getBaseSchema();
             Assert.assertEquals(4, columns.size());
 
@@ -293,5 +292,208 @@ public class LakeTableAsyncFastSchemaChangeJobTest {
             Assert.assertTrue(table.getIndexIdToMeta().get(table.getBaseIndexId()).getSchemaId() > oldSchemaId);
             Assert.assertEquals(OlapTable.OlapTableState.NORMAL, table.getState());
         }
+    }
+
+    private List<Column> getShortKeyColumns(Database db, OlapTable table) {
+        Locker locker = new Locker();
+        locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
+        try {
+            long baseIndexId = table.getBaseIndexId();
+            MaterializedIndexMeta indexMeta = table.getIndexMetaByIndexId(baseIndexId);
+            List<Column> schema = indexMeta.getSchema();
+            List<Column> shortKeyCols = new ArrayList<>();
+            List<Integer> sortKeyIdxes = indexMeta.getSortKeyIdxes();
+            int count = indexMeta.getShortKeyColumnCount();
+            if (sortKeyIdxes != null && !sortKeyIdxes.isEmpty()) {
+                for (int i = 0; i < count; i++) {
+                    shortKeyCols.add(schema.get(sortKeyIdxes.get(i)));
+                }
+            } else {
+                for (int i = 0; i < count; i++) {
+                    shortKeyCols.add(schema.get(i));
+                }
+            }
+            return shortKeyCols;
+        } finally {
+            locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
+        }
+    }
+
+    private boolean isShortKeyChanged(Database db, OlapTable table, List<Column> oldShortKeys) {
+        List<Column> newShortKeys = getShortKeyColumns(db, table);
+        if (oldShortKeys.size() != newShortKeys.size()) {
+            return true;
+        }
+        for (int i = 0; i < oldShortKeys.size(); i++) {
+            if (!oldShortKeys.get(i).equals(newShortKeys.get(i))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isSchemaMatch(Database db, OlapTable table, List<String> columNames) {
+        Locker locker = new Locker();
+        locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
+        try {
+            long baseIndexId = table.getBaseIndexId();
+            MaterializedIndexMeta indexMeta = table.getIndexMetaByIndexId(baseIndexId);
+            List<Column> schema = indexMeta.getSchema();
+            if (schema.size() != columNames.size()) {
+                return false;
+
+            }
+            for (int i = 0; i < schema.size(); i++) {
+                if (!schema.get(i).getName().equals(columNames.get(i))) {
+                    return false;
+                }
+            }
+            return true;
+        } finally {
+            locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
+        }
+    }
+
+    private void createDupTableForAddKeyColumnTest(String tableName) throws Exception {
+        String createStmt = String.format("""
+                CREATE TABLE IF NOT EXISTS %s.%s (
+                k0 DATETIME,
+                k1 INT,
+                k2 BIGINT,\
+                v0 VARCHAR(1024)
+                ) DUPLICATE  KEY(k0, k1, k2)
+                DISTRIBUTED BY HASH(k0) BUCKETS 1
+                PROPERTIES ('replication_num' = '1', 'fast_schema_evolution' = 'true');""", DB_NAME, tableName);
+        createTable(connectContext, createStmt);
+    }
+
+    private void createUniqueTableForAddKeyColumnTest(String tableName) throws Exception {
+        String createStmt = String.format("""
+                CREATE TABLE IF NOT EXISTS  %s.%s (
+                k0 DATETIME,
+                k1 INT,
+                k2 BIGINT,\
+                v0 VARCHAR(1024)
+                ) UNIQUE KEY(k0, k1, k2)
+                DISTRIBUTED BY HASH(k0) BUCKETS 1
+                PROPERTIES ('replication_num' = '1', 'fast_schema_evolution' = 'true');""", DB_NAME, tableName);
+        createTable(connectContext, createStmt);
+    }
+
+    private void createAggTableForAddKeyColumnTest(String tableName) throws Exception {
+        String createStmt = String.format("""
+                CREATE TABLE IF NOT EXISTS %s.%s (
+                k0 DATETIME,
+                k1 INT,
+                k2 BIGINT,\
+                v0 INT SUM DEFAULT '0'
+                ) AGGREGATE KEY(k0, k1, k2)
+                DISTRIBUTED BY HASH(k0) BUCKETS 1
+                PROPERTIES ('replication_num' = '1', 'fast_schema_evolution' = 'true');""", DB_NAME, tableName);
+        createTable(connectContext, createStmt);
+    }
+
+    private void testAddKeyColumnWithFastSchemaEvolutionBase(String  tableName) throws Exception {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeTable tbl = (LakeTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), tableName);
+        Assertions.assertNotNull(tbl);
+        List<Column> oldShortKeys = getShortKeyColumns(db, tbl);
+
+        executeAlterAndWaitFinish(tbl,
+                String.format("ALTER TABLE %s.%s ADD COLUMN new_k1 INT KEY DEFAULT '0'", DB_NAME, tableName), true);
+        Assertions.assertFalse(isShortKeyChanged(db, tbl, oldShortKeys));
+        Assertions.assertTrue(isSchemaMatch(db, tbl,
+                Lists.newArrayList("k0", "k1", "k2", "new_k1", "v0")));
+
+        executeAlterAndWaitFinish(tbl,
+                String.format("ALTER TABLE %s.%s ADD COLUMN new_k2 INT KEY DEFAULT NULL", DB_NAME, tableName), true);
+        Assertions.assertFalse(isShortKeyChanged(db, tbl, oldShortKeys));
+        Assertions.assertTrue(isSchemaMatch(db, tbl,
+                Lists.newArrayList("k0", "k1", "k2", "new_k1", "new_k2", "v0")));
+
+        executeAlterAndWaitFinish(tbl,
+                String.format(
+                        "ALTER TABLE %s.%s ADD COLUMN new_k3 DATETIME KEY DEFAULT CURRENT_TIMESTAMP", DB_NAME, tableName), true);
+        Assertions.assertFalse(isShortKeyChanged(db, tbl, oldShortKeys));
+        Assertions.assertTrue(isSchemaMatch(db, tbl,
+                Lists.newArrayList("k0", "k1", "k2", "new_k1", "new_k2", "new_k3", "v0")));
+
+        executeAlterAndWaitFinish(tbl,
+                String.format(
+                        "ALTER TABLE %s.%s ADD COLUMN new_k4 VARCHAR(100) KEY AFTER k2", DB_NAME, tableName), true);
+        Assertions.assertFalse(isShortKeyChanged(db, tbl, oldShortKeys));
+        Assertions.assertTrue(isSchemaMatch(db, tbl,
+                Lists.newArrayList("k0", "k1", "k2", "new_k4", "new_k1", "new_k2", "new_k3", "v0")));
+    }
+
+    private void testAddKeyColumnWithoutFastSchemaEvolutionBase(String tableName) throws Exception {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeTable tbl = (LakeTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), tableName);
+        Assertions.assertNotNull(tbl);
+        List<Column> oldShortKeys = getShortKeyColumns(db, tbl);
+
+        executeAlterAndWaitFinish(tbl,
+                String.format("ALTER TABLE %s.%s ADD COLUMN new_k1 INT KEY FIRST", DB_NAME, tableName), false);
+        Assertions.assertTrue(isShortKeyChanged(db, tbl, oldShortKeys));
+        Assertions.assertTrue(isSchemaMatch(db, tbl,
+                Lists.newArrayList("new_k1", "k0", "k1", "k2", "v0")));
+
+        oldShortKeys = getShortKeyColumns(db, tbl);
+        executeAlterAndWaitFinish(tbl,
+                String.format("ALTER TABLE %s.%s ADD COLUMN new_k2 VARCHAR(100) KEY AFTER k0", DB_NAME, tableName), false);
+        Assertions.assertTrue(isShortKeyChanged(db, tbl, oldShortKeys));
+        Assertions.assertTrue(isSchemaMatch(db, tbl,
+                Lists.newArrayList("new_k1", "k0", "new_k2", "k1", "k2", "v0")));
+
+        oldShortKeys = getShortKeyColumns(db, tbl);
+        executeAlterAndWaitFinish(tbl,
+                String.format("ALTER TABLE %s.%s MODIFY COLUMN new_k1 BIGINT KEY", DB_NAME, tableName), false);
+        Assertions.assertTrue(isShortKeyChanged(db, tbl, oldShortKeys));
+        Assertions.assertTrue(isSchemaMatch(db, tbl,
+                Lists.newArrayList("new_k1", "k0", "new_k2", "k1", "k2", "v0")));
+    }
+
+    @Test
+    public void testDupTableAddKeyColumnWithFastSchemaEvolution() throws Exception {
+        String tableName = "dup_add_key_with_fse";
+        createDupTableForAddKeyColumnTest(tableName);
+        testAddKeyColumnWithFastSchemaEvolutionBase(tableName);
+    }
+
+    @Test
+    public void testDupTableAddKeyColumnWithoutFastSchemaEvolution() throws Exception {
+        String tableName = "dup_add_key_without_fse";
+        createDupTableForAddKeyColumnTest(tableName);
+        testAddKeyColumnWithoutFastSchemaEvolutionBase(tableName);
+    }
+
+    @Test
+    public void testUniqueTableAddKeyColumnWithFastSchemaEvolution() throws Exception {
+        String tableName = "unique_add_key_with_fse";
+        createUniqueTableForAddKeyColumnTest(tableName);
+        testAddKeyColumnWithFastSchemaEvolutionBase(tableName);
+    }
+
+    @Test
+    public void testUniqueTableAddKeyColumnWithoutFastSchemaEvolution() throws Exception {
+        String tableName = "unique_add_key_without_fse";
+        createUniqueTableForAddKeyColumnTest(tableName);
+        testAddKeyColumnWithoutFastSchemaEvolutionBase(tableName);
+    }
+
+    @Test
+    public void testAggTableAddKeyColumnWithFastSchemaEvolution() throws Exception {
+        String tableName = "agg_add_key_with_fse";
+        createAggTableForAddKeyColumnTest(tableName);
+        testAddKeyColumnWithFastSchemaEvolutionBase(tableName);
+    }
+
+    @Test
+    public void testAggTableAddKeyColumnWithoutFastSchemaEvolution() throws Exception {
+        String tableName = "agg_add_key_without_fse";
+        createAggTableForAddKeyColumnTest(tableName);
+        testAddKeyColumnWithoutFastSchemaEvolutionBase(tableName);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobTest.java
@@ -74,7 +74,7 @@ public class LakeTableAsyncFastSchemaChangeJobTest {
     private AlterJobV2 getAlterJob(Table table) {
         AlterJobMgr alterJobMgr = GlobalStateMgr.getCurrentState().getAlterJobMgr();
         List<AlterJobV2> jobs = alterJobMgr.getSchemaChangeHandler().getUnfinishedAlterJobV2ByTableId(table.getId());
-        Assertions.assertEquals(1, jobs.size());
+        Assert.assertEquals(1, jobs.size());
         return jobs.get(0);
     }
 
@@ -86,8 +86,8 @@ public class LakeTableAsyncFastSchemaChangeJobTest {
             alterJob.run();
             Thread.sleep(100);
         }
-        Assertions.assertEquals(AlterJobV2.JobState.FINISHED, alterJob.getJobState());
-        Assertions.assertEquals(expectFastSchemaEvolution, (alterJob instanceof LakeTableAsyncFastSchemaChangeJob));
+        Assert.assertEquals(AlterJobV2.JobState.FINISHED, alterJob.getJobState());
+        Assert.assertEquals(expectFastSchemaEvolution, (alterJob instanceof LakeTableAsyncFastSchemaChangeJob));
         return alterJob;
     }
 
@@ -296,7 +296,7 @@ public class LakeTableAsyncFastSchemaChangeJobTest {
 
     private List<Column> getShortKeyColumns(Database db, OlapTable table) {
         Locker locker = new Locker();
-        locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
+        locker.lockTablesWithIntensiveDbLock(db, Lists.newArrayList(table.getId()), LockType.READ);
         try {
             long baseIndexId = table.getBaseIndexId();
             MaterializedIndexMeta indexMeta = table.getIndexMetaByIndexId(baseIndexId);
@@ -315,7 +315,7 @@ public class LakeTableAsyncFastSchemaChangeJobTest {
             }
             return shortKeyCols;
         } finally {
-            locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
+            locker.unLockTablesWithIntensiveDbLock(db, Lists.newArrayList(table.getId()), LockType.READ);
         }
     }
 
@@ -334,7 +334,7 @@ public class LakeTableAsyncFastSchemaChangeJobTest {
 
     private boolean isSchemaMatch(Database db, OlapTable table, List<String> columNames) {
         Locker locker = new Locker();
-        locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
+        locker.lockTablesWithIntensiveDbLock(db, Lists.newArrayList(table.getId()), LockType.READ);
         try {
             long baseIndexId = table.getBaseIndexId();
             MaterializedIndexMeta indexMeta = table.getIndexMetaByIndexId(baseIndexId);
@@ -350,46 +350,46 @@ public class LakeTableAsyncFastSchemaChangeJobTest {
             }
             return true;
         } finally {
-            locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
+            locker.unLockTablesWithIntensiveDbLock(db, Lists.newArrayList(table.getId()), LockType.READ);
         }
     }
 
     private void createDupTableForAddKeyColumnTest(String tableName) throws Exception {
-        String createStmt = String.format("""
-                CREATE TABLE IF NOT EXISTS %s.%s (
-                k0 DATETIME,
-                k1 INT,
-                k2 BIGINT,\
-                v0 VARCHAR(1024)
-                ) DUPLICATE  KEY(k0, k1, k2)
-                DISTRIBUTED BY HASH(k0) BUCKETS 1
-                PROPERTIES ('replication_num' = '1', 'fast_schema_evolution' = 'true');""", DB_NAME, tableName);
+        String createStmt = String.format(
+                "CREATE TABLE IF NOT EXISTS %s.%s (" +
+                "k0 DATETIME," +
+                "k1 INT," +
+                "k2 BIGINT," +
+                "v0 VARCHAR(1024)" +
+                ") DUPLICATE  KEY(k0, k1, k2) " +
+                "DISTRIBUTED BY HASH(k0) BUCKETS 1 " +
+                "PROPERTIES ('replication_num' = '1', 'fast_schema_evolution' = 'true');", DB_NAME, tableName);
         createTable(connectContext, createStmt);
     }
 
     private void createUniqueTableForAddKeyColumnTest(String tableName) throws Exception {
-        String createStmt = String.format("""
-                CREATE TABLE IF NOT EXISTS  %s.%s (
-                k0 DATETIME,
-                k1 INT,
-                k2 BIGINT,\
-                v0 VARCHAR(1024)
-                ) UNIQUE KEY(k0, k1, k2)
-                DISTRIBUTED BY HASH(k0) BUCKETS 1
-                PROPERTIES ('replication_num' = '1', 'fast_schema_evolution' = 'true');""", DB_NAME, tableName);
+        String createStmt = String.format(
+                "CREATE TABLE IF NOT EXISTS %s.%s (" +
+                "k0 DATETIME," +
+                "k1 INT," +
+                "k2 BIGINT," +
+                "v0 VARCHAR(1024)" +
+                ") UNIQUE KEY(k0, k1, k2) " +
+                "DISTRIBUTED BY HASH(k0) BUCKETS 1 " +
+                "PROPERTIES ('replication_num' = '1', 'fast_schema_evolution' = 'true');", DB_NAME, tableName);
         createTable(connectContext, createStmt);
     }
 
     private void createAggTableForAddKeyColumnTest(String tableName) throws Exception {
-        String createStmt = String.format("""
-                CREATE TABLE IF NOT EXISTS %s.%s (
-                k0 DATETIME,
-                k1 INT,
-                k2 BIGINT,\
-                v0 INT SUM DEFAULT '0'
-                ) AGGREGATE KEY(k0, k1, k2)
-                DISTRIBUTED BY HASH(k0) BUCKETS 1
-                PROPERTIES ('replication_num' = '1', 'fast_schema_evolution' = 'true');""", DB_NAME, tableName);
+        String createStmt = String.format(
+                "CREATE TABLE IF NOT EXISTS %s.%s (" +
+                "k0 DATETIME," +
+                "k1 INT," +
+                "k2 BIGINT," +
+                "v0 INT SUM DEFAULT '0'" +
+                ") AGGREGATE KEY(k0, k1, k2) " +
+                "DISTRIBUTED BY HASH(k0) BUCKETS 1 " +
+                "PROPERTIES ('replication_num' = '1', 'fast_schema_evolution' = 'true');", DB_NAME, tableName);
         createTable(connectContext, createStmt);
     }
 
@@ -397,33 +397,33 @@ public class LakeTableAsyncFastSchemaChangeJobTest {
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
         LakeTable tbl = (LakeTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
                 .getTable(db.getFullName(), tableName);
-        Assertions.assertNotNull(tbl);
+        Assert.assertNotNull(tbl);
         List<Column> oldShortKeys = getShortKeyColumns(db, tbl);
 
         executeAlterAndWaitFinish(tbl,
                 String.format("ALTER TABLE %s.%s ADD COLUMN new_k1 INT KEY DEFAULT '0'", DB_NAME, tableName), true);
-        Assertions.assertFalse(isShortKeyChanged(db, tbl, oldShortKeys));
-        Assertions.assertTrue(isSchemaMatch(db, tbl,
+        Assert.assertFalse(isShortKeyChanged(db, tbl, oldShortKeys));
+        Assert.assertTrue(isSchemaMatch(db, tbl,
                 Lists.newArrayList("k0", "k1", "k2", "new_k1", "v0")));
 
         executeAlterAndWaitFinish(tbl,
                 String.format("ALTER TABLE %s.%s ADD COLUMN new_k2 INT KEY DEFAULT NULL", DB_NAME, tableName), true);
-        Assertions.assertFalse(isShortKeyChanged(db, tbl, oldShortKeys));
-        Assertions.assertTrue(isSchemaMatch(db, tbl,
+        Assert.assertFalse(isShortKeyChanged(db, tbl, oldShortKeys));
+        Assert.assertTrue(isSchemaMatch(db, tbl,
                 Lists.newArrayList("k0", "k1", "k2", "new_k1", "new_k2", "v0")));
 
         executeAlterAndWaitFinish(tbl,
                 String.format(
                         "ALTER TABLE %s.%s ADD COLUMN new_k3 DATETIME KEY DEFAULT CURRENT_TIMESTAMP", DB_NAME, tableName), true);
-        Assertions.assertFalse(isShortKeyChanged(db, tbl, oldShortKeys));
-        Assertions.assertTrue(isSchemaMatch(db, tbl,
+        Assert.assertFalse(isShortKeyChanged(db, tbl, oldShortKeys));
+        Assert.assertTrue(isSchemaMatch(db, tbl,
                 Lists.newArrayList("k0", "k1", "k2", "new_k1", "new_k2", "new_k3", "v0")));
 
         executeAlterAndWaitFinish(tbl,
                 String.format(
                         "ALTER TABLE %s.%s ADD COLUMN new_k4 VARCHAR(100) KEY AFTER k2", DB_NAME, tableName), true);
-        Assertions.assertFalse(isShortKeyChanged(db, tbl, oldShortKeys));
-        Assertions.assertTrue(isSchemaMatch(db, tbl,
+        Assert.assertFalse(isShortKeyChanged(db, tbl, oldShortKeys));
+        Assert.assertTrue(isSchemaMatch(db, tbl,
                 Lists.newArrayList("k0", "k1", "k2", "new_k4", "new_k1", "new_k2", "new_k3", "v0")));
     }
 
@@ -431,27 +431,27 @@ public class LakeTableAsyncFastSchemaChangeJobTest {
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
         LakeTable tbl = (LakeTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
                 .getTable(db.getFullName(), tableName);
-        Assertions.assertNotNull(tbl);
+        Assert.assertNotNull(tbl);
         List<Column> oldShortKeys = getShortKeyColumns(db, tbl);
 
         executeAlterAndWaitFinish(tbl,
                 String.format("ALTER TABLE %s.%s ADD COLUMN new_k1 INT KEY FIRST", DB_NAME, tableName), false);
-        Assertions.assertTrue(isShortKeyChanged(db, tbl, oldShortKeys));
-        Assertions.assertTrue(isSchemaMatch(db, tbl,
+        Assert.assertTrue(isShortKeyChanged(db, tbl, oldShortKeys));
+        Assert.assertTrue(isSchemaMatch(db, tbl,
                 Lists.newArrayList("new_k1", "k0", "k1", "k2", "v0")));
 
         oldShortKeys = getShortKeyColumns(db, tbl);
         executeAlterAndWaitFinish(tbl,
                 String.format("ALTER TABLE %s.%s ADD COLUMN new_k2 VARCHAR(100) KEY AFTER k0", DB_NAME, tableName), false);
-        Assertions.assertTrue(isShortKeyChanged(db, tbl, oldShortKeys));
-        Assertions.assertTrue(isSchemaMatch(db, tbl,
+        Assert.assertTrue(isShortKeyChanged(db, tbl, oldShortKeys));
+        Assert.assertTrue(isSchemaMatch(db, tbl,
                 Lists.newArrayList("new_k1", "k0", "new_k2", "k1", "k2", "v0")));
 
         oldShortKeys = getShortKeyColumns(db, tbl);
         executeAlterAndWaitFinish(tbl,
                 String.format("ALTER TABLE %s.%s MODIFY COLUMN new_k1 BIGINT KEY", DB_NAME, tableName), false);
-        Assertions.assertTrue(isShortKeyChanged(db, tbl, oldShortKeys));
-        Assertions.assertTrue(isSchemaMatch(db, tbl,
+        Assert.assertTrue(isShortKeyChanged(db, tbl, oldShortKeys));
+        Assert.assertTrue(isSchemaMatch(db, tbl,
                 Lists.newArrayList("new_k1", "k0", "new_k2", "k1", "k2", "v0")));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/CacheSelectBackendSelectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/CacheSelectBackendSelectorTest.java
@@ -198,6 +198,10 @@ public class CacheSelectBackendSelectorTest {
 
                 globalStateMgr.getStarOSAgent();
                 result = starOsAgent;
+                
+                globalStateMgr.getServingState();
+                minTimes = 0;
+                result = globalStateMgr;
             }
         };
         new Expectations() {
@@ -415,6 +419,10 @@ public class CacheSelectBackendSelectorTest {
 
                 globalStateMgr.getStarOSAgent();
                 result = starOsAgent;
+                
+                globalStateMgr.getServingState();
+                minTimes = 0;
+                result = globalStateMgr;
             }
         };
         new Expectations() {
@@ -493,6 +501,10 @@ public class CacheSelectBackendSelectorTest {
 
                 globalStateMgr.getStarOSAgent();
                 result = starOsAgent;
+                
+                globalStateMgr.getServingState();
+                minTimes = 0;
+                result = globalStateMgr;
             }
         };
         WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
@@ -712,6 +724,10 @@ public class CacheSelectBackendSelectorTest {
 
                 globalStateMgr.getStarOSAgent();
                 result = starOsAgent;
+                
+                globalStateMgr.getServingState();
+                minTimes = 0;
+                result = globalStateMgr;
             }
         };
         Long starOsPreferredCnId = -1L;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
1. Cherrypicked https://github.com/StarRocks/starrocks/commit/35eb1f2ab8ef5a308400f386f0d55394d5b8af7f into pinterest-integration-3.3. This required minor manual steps to resolve conflicts, especially in the tests, which are using different version of test-module dependencies
2. Fixed unrelated unit test problem in fe/fe-core/src/test/java/com/starrocks/qe/CacheSelectBackendSelectorTest.java 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0