### PR TITLE
Cherrypicking fixes for cache select failures following column addition

### DIFF
--- a/be/src/storage/rowset/array_column_iterator.h
+++ b/be/src/storage/rowset/array_column_iterator.h
@@ -64,6 +64,9 @@ public:
 
     ColumnReader* get_column_reader() override { return _reader; }
 
+    StatusOr<std::vector<std::pair<int64_t, int64_t>>> get_io_range_vec(const SparseRange<>& range,
+                                                                        Column* dst) override;
+
 private:
     [[nodiscard]] Status next_batch_null_offsets(size_t* n, UInt32Column* offsets, UInt8Column* nulls,
                                                  size_t* element_rows);

--- a/be/src/storage/rowset/cast_column_iterator.cpp
+++ b/be/src/storage/rowset/cast_column_iterator.cpp
@@ -77,4 +77,10 @@ Status CastColumnIterator::fetch_values_by_rowid(const rowid_t* rowids, size_t s
     return Status::OK();
 }
 
+StatusOr<std::vector<std::pair<int64_t, int64_t>>> CastColumnIterator::get_io_range_vec(const SparseRange<>& range,
+                                                                                        Column* dst) {
+    auto source_column = _source_chunk.get_column_by_index(0);
+    return _parent->get_io_range_vec(range, source_column.get());
+}
+
 } // namespace starrocks

--- a/be/src/storage/rowset/cast_column_iterator.h
+++ b/be/src/storage/rowset/cast_column_iterator.h
@@ -50,6 +50,9 @@ public:
         return Status::OK();
     }
 
+    StatusOr<std::vector<std::pair<int64_t, int64_t>>> get_io_range_vec(const SparseRange<>& range,
+                                                                        Column* dst) override;
+
 private:
     void do_cast(Column* target);
 

--- a/be/src/storage/rowset/default_value_column_iterator.h
+++ b/be/src/storage/rowset/default_value_column_iterator.h
@@ -94,6 +94,11 @@ public:
 
     [[nodiscard]] Status fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* values) override;
 
+    StatusOr<std::vector<std::pair<int64_t, int64_t>>> get_io_range_vec(const SparseRange<>& range,
+                                                                        Column* dst) override {
+        return std::vector<std::pair<int64_t, int64_t>>();
+    }
+
 private:
     bool _has_default_value;
     std::string _default_value;

--- a/be/src/storage/rowset/map_column_iterator.cpp
+++ b/be/src/storage/rowset/map_column_iterator.cpp
@@ -149,47 +149,9 @@ Status MapColumnIterator::next_batch(const SparseRange<>& range, Column* dst) {
         down_cast<NullableColumn*>(dst)->update_has_null();
     }
 
-    SparseRangeIterator<> iter = range.new_iterator();
-    size_t to_read = range.span_size();
-
-    // array column can be nested, range may be empty
-    DCHECK(range.empty() || (range.begin() == _offsets->get_current_ordinal()));
     SparseRange element_read_range;
     size_t read_rows = 0;
-    while (iter.has_more()) {
-        Range<> r = iter.next(to_read);
-
-        RETURN_IF_ERROR(_offsets->seek_to_ordinal_and_calc_element_ordinal(r.begin()));
-        size_t element_ordinal = _offsets->element_ordinal();
-        // if array column in nullable or element of array is empty, element_read_range may be empty.
-        // so we should reseek the element_ordinal
-        if (element_read_range.span_size() == 0) {
-            RETURN_IF_ERROR(_keys->seek_to_ordinal(element_ordinal));
-            RETURN_IF_ERROR(_values->seek_to_ordinal(element_ordinal));
-        }
-        // 2. Read offset column
-        // [1, 2, 3], [4, 5, 6]
-        // In memory, it will be transformed to actual offset(0, 3, 6)
-        // On disk, offset is stored as length array(3, 3)
-        auto* offsets = map_column->offsets_column().get();
-        auto& data = offsets->get_data();
-        size_t end_offset = data.back();
-
-        size_t prev_array_size = offsets->size();
-        SparseRange<> size_read_range(r);
-        RETURN_IF_ERROR(_offsets->next_batch(size_read_range, offsets));
-        size_t curr_array_size = offsets->size();
-
-        size_t num_to_read = end_offset;
-        for (size_t i = prev_array_size; i < curr_array_size; ++i) {
-            end_offset += data[i];
-            data[i] = end_offset;
-        }
-        num_to_read = end_offset - num_to_read;
-        read_rows += num_to_read;
-
-        element_read_range.add(Range<>(element_ordinal, element_ordinal + num_to_read));
-    }
+    RETURN_IF_ERROR(get_element_range_vec(range, map_column, true /* seek */, element_read_range, read_rows));
 
     // if array column is nullable, element_read_range may be empty
     DCHECK(element_read_range.empty() || (element_read_range.begin() == _keys->get_current_ordinal()));
@@ -306,6 +268,83 @@ Status MapColumnIterator::seek_to_ordinal(ordinal_t ord) {
     RETURN_IF_ERROR(_keys->seek_to_ordinal(element_ordinal));
     RETURN_IF_ERROR(_values->seek_to_ordinal(element_ordinal));
     return Status::OK();
+}
+
+Status MapColumnIterator::get_element_range_vec(const SparseRange<>& range, MapColumn* map_column, bool seek,
+                                                SparseRange<>& element_read_range, size_t& read_rows) {
+    SparseRangeIterator<> iter = range.new_iterator();
+    size_t to_read = range.span_size();
+
+    // array column can be nested, range may be empty
+    DCHECK(range.empty() || (range.begin() == _offsets->get_current_ordinal()));
+    element_read_range.clear();
+    read_rows = 0;
+    while (iter.has_more()) {
+        Range<> r = iter.next(to_read);
+
+        RETURN_IF_ERROR(_offsets->seek_to_ordinal_and_calc_element_ordinal(r.begin()));
+        size_t element_ordinal = _offsets->element_ordinal();
+        // if array column in nullable or element of array is empty, element_read_range may be empty.
+        // so we should reseek the element_ordinal
+        if (seek && element_read_range.span_size() == 0) {
+            RETURN_IF_ERROR(_keys->seek_to_ordinal(element_ordinal));
+            RETURN_IF_ERROR(_values->seek_to_ordinal(element_ordinal));
+        }
+        // 2. Read offset column
+        // [1, 2, 3], [4, 5, 6]
+        // In memory, it will be transformed to actual offset(0, 3, 6)
+        // On disk, offset is stored as length array(3, 3)
+        auto* offsets = map_column->offsets_column().get();
+        auto& data = offsets->get_data();
+        size_t end_offset = data.back();
+
+        size_t prev_array_size = offsets->size();
+        SparseRange<> size_read_range(r);
+        RETURN_IF_ERROR(_offsets->next_batch(size_read_range, offsets));
+        size_t curr_array_size = offsets->size();
+
+        size_t num_to_read = end_offset;
+        for (size_t i = prev_array_size; i < curr_array_size; ++i) {
+            end_offset += data[i];
+            data[i] = end_offset;
+        }
+        num_to_read = end_offset - num_to_read;
+        read_rows += num_to_read;
+
+        element_read_range.add(Range<>(element_ordinal, element_ordinal + num_to_read));
+    }
+
+    return Status::OK();
+}
+
+StatusOr<std::vector<std::pair<int64_t, int64_t>>> MapColumnIterator::get_io_range_vec(const SparseRange<>& range,
+                                                                                       Column* dst) {
+    MapColumn* map_column = nullptr;
+    if (dst->is_nullable()) {
+        auto* nullable_column = down_cast<NullableColumn*>(dst);
+        map_column = down_cast<MapColumn*>(nullable_column->data_column().get());
+    } else {
+        map_column = down_cast<MapColumn*>(dst);
+    }
+
+    std::vector<std::pair<int64_t, int64_t>> res;
+    if (_nulls != nullptr) {
+        ASSIGN_OR_RETURN(auto vec, _nulls->get_io_range_vec(range, dst));
+        res.insert(res.end(), vec.begin(), vec.end());
+    }
+
+    SparseRange element_read_range;
+    size_t read_rows = 0;
+    RETURN_IF_ERROR(get_element_range_vec(range, map_column, false /* seek */, element_read_range, read_rows));
+    if (_access_keys) {
+        ASSIGN_OR_RETURN(auto vec, _keys->get_io_range_vec(element_read_range, dst));
+        res.insert(res.end(), vec.begin(), vec.end());
+    }
+    if (_access_values) {
+        ASSIGN_OR_RETURN(auto vec, _values->get_io_range_vec(element_read_range, dst));
+        res.insert(res.end(), vec.begin(), vec.end());
+    }
+    return res;
 }
 
 } // namespace starrocks

--- a/be/src/storage/rowset/map_column_iterator.h
+++ b/be/src/storage/rowset/map_column_iterator.h
@@ -46,7 +46,13 @@ public:
 
     ColumnReader* get_column_reader() override { return _reader; }
 
+    StatusOr<std::vector<std::pair<int64_t, int64_t>>> get_io_range_vec(const SparseRange<>& range,
+                                                                        Column* dst) override;
+
 private:
+    Status get_element_range_vec(const SparseRange<>& range, MapColumn* map_column, bool seek,
+                                 SparseRange<>& element_read_range, size_t& read_rows);
+
     ColumnReader* _reader;
 
     std::unique_ptr<ColumnIterator> _nulls;

--- a/be/src/storage/rowset/scalar_column_iterator.cpp
+++ b/be/src/storage/rowset/scalar_column_iterator.cpp
@@ -641,4 +641,47 @@ bool ScalarColumnIterator::_contains_deleted_row(uint32_t page_index) const {
     return true;
 }
 
+StatusOr<std::vector<std::pair<int64_t, int64_t>>> ScalarColumnIterator::get_io_range_vec(const SparseRange<>& range,
+                                                                                          Column* dst) {
+    (void)dst;
+    std::vector<std::pair<int64_t, int64_t>> res;
+    auto reader = get_column_reader();
+    if (reader == nullptr) {
+        // should't happen
+        return Status::InvalidArgument(fmt::format("column reader for {} is nullptr", _opts.read_file->filename()));
+    }
+
+    std::vector<std::pair<int, int>> page_index;
+    int prev_page_index = -1;
+    for (auto index = 0; index < range.size(); index++) {
+        auto row_start = range[index].begin();
+        auto row_end = range[index].end() - 1;
+        OrdinalPageIndexIterator iter_start;
+        OrdinalPageIndexIterator iter_end;
+        RETURN_IF_ERROR(reader->seek_at_or_before(row_start, &iter_start));
+        RETURN_IF_ERROR(reader->seek_at_or_before(row_end, &iter_end));
+
+        if (prev_page_index == iter_start.page_index()) {
+            // merge page index
+            page_index.back().second = iter_end.page_index();
+        } else {
+            page_index.emplace_back(std::make_pair(iter_start.page_index(), iter_end.page_index()));
+        }
+
+        prev_page_index = iter_end.page_index();
+    }
+
+    for (auto pair : page_index) {
+        OrdinalPageIndexIterator iter_start;
+        OrdinalPageIndexIterator iter_end;
+        RETURN_IF_ERROR(reader->seek_by_page_index(pair.first, &iter_start));
+        RETURN_IF_ERROR(reader->seek_by_page_index(pair.second, &iter_end));
+        auto offset = iter_start.page().offset;
+        auto size = iter_end.page().offset - offset + iter_end.page().size;
+        res.emplace_back(offset, size);
+    }
+
+    return res;
+}
+
 } // namespace starrocks

--- a/be/src/storage/rowset/scalar_column_iterator.h
+++ b/be/src/storage/rowset/scalar_column_iterator.h
@@ -100,6 +100,9 @@ public:
     // used to acquire load local dict
     int dict_size() override;
 
+    StatusOr<std::vector<std::pair<int64_t, int64_t>>> get_io_range_vec(const SparseRange<>& range,
+                                                                        Column* dst) override;
+
 private:
     static Status _seek_to_pos_in_page(ParsedPage* page, ordinal_t offset_in_page);
     Status _load_next_page(bool* eos);

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -1126,8 +1126,15 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
         if (buf_size <= 0) {
             buf_size = 1048576; // 1MB
         }
-        for (auto& [cid, stream] : _column_files) {
-            ASSIGN_OR_RETURN(auto vec, _column_iterators[cid]->get_io_range_vec(_scan_range));
+        _context->_read_chunk->reset();
+        Chunk* chunk = _context->_read_chunk.get();
+        size_t column_index = 0;
+        for (size_t cid = 0; cid < _column_iterators.size(); ++cid) {
+            if (_column_iterators[cid] == nullptr) {
+                continue;
+            }
+            ColumnPtr& col = chunk->get_column_by_index(column_index++);
+            ASSIGN_OR_RETURN(auto vec, _column_iterators[cid]->get_io_range_vec(_scan_range, col.get()));
             for (auto e : vec) {
                 // if buf_size is 1MB, offset is 123, and size is 2MB
                 // after calculation, offset will be 0, and size will be 2MB+123
@@ -1135,7 +1142,7 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
                 size_t size = e.second + (e.first % buf_size);
                 while (size > 0) {
                     size_t cur_size = std::min(buf_size, size);
-                    RETURN_IF_ERROR(stream->touch_cache(offset, cur_size));
+                    RETURN_IF_ERROR(_column_files[cid]->touch_cache(offset, cur_size));
                     offset += cur_size;
                     size -= cur_size;
                 }
@@ -1621,6 +1628,10 @@ Status SegmentIterator::_init_context() {
             }
         }
 
+        if (_opts.lake_io_opts.cache_file_only) {
+            // CACHE SELECT disable late materialization
+            _late_materialization_ratio = 0;
+        }
         if (_late_materialization_ratio <= 0) {
             // late materialization been disabled.
             RETURN_IF_ERROR(_build_context<false>(&_context_list[0]));

--- a/be/src/storage/rowset/struct_column_iterator.cpp
+++ b/be/src/storage/rowset/struct_column_iterator.cpp
@@ -58,6 +58,9 @@ public:
 
     ColumnReader* get_column_reader() override { return _reader; }
 
+    StatusOr<std::vector<std::pair<int64_t, int64_t>>> get_io_range_vec(const SparseRange<>& range,
+                                                                        Column* dst) override;
+
 private:
     ColumnReader* _reader;
 
@@ -170,6 +173,21 @@ Status StructColumnIterator::next_batch(const SparseRange<>& range, Column* dst)
 
     _current_ordinal = _access_iters[0]->get_current_ordinal();
     return Status::OK();
+}
+
+StatusOr<std::vector<std::pair<int64_t, int64_t>>> StructColumnIterator::get_io_range_vec(const SparseRange<>& range,
+                                                                                          Column* dst) {
+    std::vector<std::pair<int64_t, int64_t>> res;
+    if (_null_iter != nullptr) {
+        ASSIGN_OR_RETURN(auto vec, _null_iter->get_io_range_vec(range, dst));
+        res.insert(res.end(), vec.begin(), vec.end());
+    }
+
+    for (size_t i = 0; i < _access_iters.size(); i++) {
+        ASSIGN_OR_RETURN(auto vec, _access_iters[i]->get_io_range_vec(range, dst));
+        res.insert(res.end(), vec.begin(), vec.end());
+    }
+    return res;
 }
 
 Status StructColumnIterator::fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* values) {


### PR DESCRIPTION
## Why I'm doing:
Cache select after adding columns was giving errors e.g. 
```
mysql> cache select test_col_int1 from ads_metrics_onsite_batch_daily_staging;
ERROR 5025 (HY000): column reader for staros://24076738/data/00000000013be6bc_0c70f078-51a0-4048-81a9-7978f04eb926.dat is nullptr: BE:23908109

mysql> cache select test_col_string1 from ads_metrics_onsite_batch_daily_staging;
ERROR 5025 (HY000): column reader for staros://23711493/data/0000000001213750_073f212c-599c-4611-8d10-ab971b505342.dat is nullptr: BE:23908108
```
## What I'm doing:

Fixing known issue by cherrypicking 
https://github.com/StarRocks/starrocks/commit/b4aaddefdbfc37c3348055412bff718e0524c2fd 
and 
https://github.com/StarRocks/starrocks/commit/130b2dfe1cf96493227ee229aebb60e12bc678a0 

```
git cherry-pick b4aaddefdbfc37c3348055412bff718e0524c2fd
git cherry-pick 130b2dfe1cf96493227ee229aebb60e12bc678a0
```
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool
