### PR TITLE
Add cauthz_fail_open and cauthz_pastis_endpoint to FE Config

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1790,6 +1790,13 @@ public class Config extends ConfigBase {
     @ConfField(mutable = false)
     public static String cauthz_authorization_class_name = "";
 
+    @ConfField(mutable = true)
+    public static boolean cauthz_fail_open = false;
+
+    /** Pastis cAuthZ path: empty = {@code cauthz/}, {@code prod} = {@code cauthz_prod/}, {@code test} = {@code cauthz_test/}. */
+    @ConfField(mutable = true)
+    public static String cauthz_pastis_endpoint = "";
+
     /**
      * The authentication_chain configuration specifies the sequence of security integrations
      * that will be used to authenticate a user. Each security integration in the chain will be


### PR DESCRIPTION
Adds FE config fields used by Pinterest cauthz: `cauthz_fail_open` and Pastis path selection `cauthz_pastis_endpoint` (cauthz / cauthz_prod / cauthz_test).