### PR TITLE
Add cauthz_pastis_endpoint to FE Config (3.3.5)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1790,6 +1790,10 @@ public class Config extends ConfigBase {
     @ConfField(mutable = false)
     public static String cauthz_authorization_class_name = "";
 
+    /** Pastis cAuthZ path: empty = {@code cauthz/}, {@code prod} = {@code cauthz_prod/}, {@code test} = {@code cauthz_test/}. */
+    @ConfField(mutable = true)
+    public static String cauthz_pastis_endpoint = "";
+
     /**
      * The authentication_chain configuration specifies the sequence of security integrations
      * that will be used to authenticate a user. Each security integration in the chain will be


### PR DESCRIPTION
Adds `cauthz_pastis_endpoint` for Pastis cAuthZ path: legacy `cauthz/`, `cauthz_prod/`, or `cauthz_test/`.