### PR TITLE
Add cauthz_pastis_endpoint to FE Config (3.4)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1841,6 +1841,10 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static boolean cauthz_fail_open = false;
 
+    /** Pastis cAuthZ path: empty = {@code cauthz/}, {@code prod} = {@code cauthz_prod/}, {@code test} = {@code cauthz_test/}. */
+    @ConfField(mutable = true)
+    public static String cauthz_pastis_endpoint = "";
+
     /**
      * The authentication_chain configuration specifies the sequence of security integrations
      * that will be used to authenticate a user. Each security integration in the chain will be


### PR DESCRIPTION
Adds `cauthz_pastis_endpoint` for Pastis cAuthZ path (same semantics as 3.3.5 PR).