### PR TITLE
Fix partial update hang/error on tables with GIN indexes for shared-nothing

### DIFF
--- a/be/src/storage/rowset/segment_rewriter.cpp
+++ b/be/src/storage/rowset/segment_rewriter.cpp
@@ -25,7 +25,8 @@ SegmentRewriter::SegmentRewriter() = default;
 Status SegmentRewriter::rewrite_partial_update(const FileInfo& src, FileInfo* dest,
                                                const std::shared_ptr<const TabletSchema>& tschema,
                                                std::vector<uint32_t>& column_ids, MutableColumns& columns,
-                                               uint32_t segment_id, const FooterPointerPB& partial_rowset_footer) {
+                                               uint32_t segment_id, const FooterPointerPB& partial_rowset_footer,
+                                               SegmentFileMark segment_file_mark) {
     constexpr size_t kBufferSize = 1024 * 1024; // 1 MB
     if (UNLIKELY(column_ids.empty())) {
         // In shared-nothing mode, this size can be null, and we don't need it so it's ok to return zero;
@@ -66,6 +67,7 @@ Status SegmentRewriter::rewrite_partial_update(const FileInfo& src, FileInfo* de
     }
 
     SegmentWriterOptions opts;
+    opts.segment_file_mark = std::move(segment_file_mark);
     SegmentWriter writer(std::move(wfile), segment_id, tschema, opts);
     RETURN_IF_ERROR(writer.init(column_ids, false, &footer));
 
@@ -91,7 +93,8 @@ Status SegmentRewriter::rewrite_partial_update(const FileInfo& src, FileInfo* de
 Status SegmentRewriter::rewrite_auto_increment(const std::string& src_path, const std::string& dest_path,
                                                const TabletSchemaCSPtr& tschema,
                                                AutoIncrementPartialUpdateState& auto_increment_partial_update_state,
-                                               std::vector<uint32_t>& column_ids, MutableColumns* columns) {
+                                               std::vector<uint32_t>& column_ids, MutableColumns* columns,
+                                               SegmentFileMark segment_file_mark) {
     if (column_ids.size() == 0) {
         DCHECK_EQ(columns, nullptr);
     }
@@ -163,6 +166,7 @@ Status SegmentRewriter::rewrite_auto_increment(const std::string& src_path, cons
     }
 
     SegmentWriterOptions opts;
+    opts.segment_file_mark = std::move(segment_file_mark);
     SegmentWriter writer(std::move(wfile), segment_id, tschema, opts);
     RETURN_IF_ERROR(writer.init(full_column_ids, true));
 

--- a/be/src/storage/rowset/segment_rewriter.h
+++ b/be/src/storage/rowset/segment_rewriter.h
@@ -9,6 +9,7 @@
 #include "common/statusor.h"
 #include "gen_cpp/olap_file.pb.h"
 #include "storage/lake/rowset_update_state.h"
+#include "storage/rowset/segment_writer.h"
 #include "storage/rowset_update_state.h"
 
 namespace starrocks {
@@ -29,11 +30,13 @@ public:
     static Status rewrite_partial_update(const FileInfo& src, FileInfo* dest,
                                          const std::shared_ptr<const TabletSchema>& tschema,
                                          std::vector<uint32_t>& column_ids, MutableColumns& columns,
-                                         uint32_t segment_id, const FooterPointerPB& partial_rowset_footer);
+                                         uint32_t segment_id, const FooterPointerPB& partial_rowset_footer,
+                                         SegmentFileMark segment_file_mark = {});
     static Status rewrite_auto_increment(const std::string& src_path, const std::string& dest_path,
                                          const TabletSchemaCSPtr& tschema,
                                          AutoIncrementPartialUpdateState& auto_increment_partial_update_state,
-                                         std::vector<uint32_t>& column_ids, MutableColumns* columns);
+                                         std::vector<uint32_t>& column_ids, MutableColumns* columns,
+                                         SegmentFileMark segment_file_mark = {});
     static Status rewrite_auto_increment_lake(
             const FileInfo& src, FileInfo* dest, const TabletSchemaCSPtr& tschema,
             starrocks::lake::AutoIncrementPartialUpdateState& auto_increment_partial_update_state,

--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -787,14 +787,16 @@ Status RowsetUpdateState::apply(Tablet* tablet, const TabletSchemaCSPtr& tablet_
         !_auto_increment_partial_update_states[segment_id].skip_rewrite) {
         RETURN_IF_ERROR(SegmentRewriter::rewrite_auto_increment(
                 src_path, dest_path, _tablet_schema, _auto_increment_partial_update_states[segment_id], read_column_ids,
-                _partial_update_states.size() != 0 ? &_partial_update_states[segment_id].write_columns : nullptr));
+                _partial_update_states.size() != 0 ? &_partial_update_states[segment_id].write_columns : nullptr,
+                {rowset->rowset_path(), rowset->rowset_id().to_string()}));
     } else if (_partial_update_states.size() != 0) {
         FooterPointerPB partial_rowset_footer = txn_meta.partial_rowset_footers(segment_id);
         FileInfo src{.path = src_path};
         FileInfo dest{.path = dest_path};
-        RETURN_IF_ERROR(SegmentRewriter::rewrite_partial_update(src, &dest, _tablet_schema, read_column_ids,
-                                                                _partial_update_states[segment_id].write_columns,
-                                                                segment_id, partial_rowset_footer));
+        RETURN_IF_ERROR(SegmentRewriter::rewrite_partial_update(
+                src, &dest, _tablet_schema, read_column_ids, _partial_update_states[segment_id].write_columns,
+                segment_id, partial_rowset_footer,
+                {rowset->rowset_path(), rowset->rowset_id().to_string()}));
     }
     int64_t t_rewrite_end = MonotonicMillis();
 

--- a/test/sql/test_insert_empty/R/test_insert_partial_update
+++ b/test/sql/test_insert_empty/R/test_insert_partial_update
@@ -125,3 +125,38 @@ select * from t_non_replicated_storage_multi_replica_pk;
 -- result:
 abc	10	10
 -- !result
+-- name: test_insert_partial_update_with_inverted_index @native
+ADMIN SET FRONTEND CONFIG ("enable_experimental_gin" = "true");
+-- result:
+-- !result
+CREATE TABLE t_gin (
+    pk BIGINT NOT NULL,
+    v1 INT NOT NULL DEFAULT '0',
+    title VARCHAR(255) NOT NULL DEFAULT '',
+    INDEX gin_title (title) USING GIN ("parser" = "english")
+)
+PRIMARY KEY(pk)
+DISTRIBUTED BY HASH(pk) BUCKETS 1
+PROPERTIES ("replicated_storage" = "true", "replication_num" = "1");
+-- result:
+-- !result
+insert into t_gin values (1, 100, 'hello world'), (2, 200, 'starrocks rocks');
+-- result:
+-- !result
+insert into t_gin (pk, v1) values (1, 111), (3, 300);
+-- result:
+-- !result
+select pk, v1, title from t_gin order by pk;
+-- result:
+1	111	hello world
+2	200	starrocks rocks
+3	300	
+-- !result
+select pk from t_gin where title match 'hello' order by pk;
+-- result:
+1
+-- !result
+select pk from t_gin where title match 'starrocks' order by pk;
+-- result:
+2
+-- !result

--- a/test/sql/test_insert_empty/T/test_insert_partial_update
+++ b/test/sql/test_insert_empty/T/test_insert_partial_update
@@ -65,3 +65,23 @@ PROPERTIES (
 
 insert into t_non_replicated_storage_multi_replica_pk (k,v2) select "abc", 10;
 select * from t_non_replicated_storage_multi_replica_pk;
+
+-- name: test_insert_partial_update_with_inverted_index @native
+ADMIN SET FRONTEND CONFIG ("enable_experimental_gin" = "true");
+CREATE TABLE t_gin (
+    pk BIGINT NOT NULL,
+    v1 INT NOT NULL DEFAULT '0',
+    title VARCHAR(255) NOT NULL DEFAULT '',
+    INDEX gin_title (title) USING GIN ("parser" = "english")
+)
+PRIMARY KEY(pk)
+DISTRIBUTED BY HASH(pk) BUCKETS 1
+PROPERTIES ("replicated_storage" = "true", "replication_num" = "1");
+
+insert into t_gin values (1, 100, 'hello world'), (2, 200, 'starrocks rocks');
+-- partial INSERT omitting the GIN-indexed column must succeed (regression: used to hang/fail)
+insert into t_gin (pk, v1) values (1, 111), (3, 300);
+select pk, v1, title from t_gin order by pk;
+-- GIN MATCH queries must still work after the partial update
+select pk from t_gin where title match 'hello' order by pk;
+select pk from t_gin where title match 'starrocks' order by pk;


### PR DESCRIPTION
## Why I'm doing:
Partial updates on tables with GIN (inverted) indexes were failing in multiple ways:
  - INSERT with partial columns: Queries would hang indefinitely when the GIN-indexed column was omitted;
  - Routine Load partial updates: Upserts do not work when the GIN-indexed column was omitted;
  - Broker Load partial updates: I suspect there were some instabilities caused by the same problem.

The root cause was that SegmentRewriter::rewrite_partial_update() created a SegmentWriter with uninitialized
  segment_file_mark (empty rowset_path_prefix and rowset_id). When the writer tried to create inverted index files for
  GIN-indexed columns, it generated invalid file paths, causing initialization failures and corrupted index state.

## What I'm doing:
1. Modified SegmentRewriter::rewrite_partial_update() to accept a SegmentFileMark parameter containing the rowset path prefix and rowset ID
  2. Updated callers to pass the correct rowset path information:
    - RowsetUpdateState::apply() (shared-nothing mode): passes rowset->rowset_path() and rowset->rowset_id()
    - lake::RowsetUpdateState::rewrite_segment() (shared-data mode): passes root_path and rowset metadata ID
  3. Initialize SegmentWriterOptions.segment_file_mark before creating the SegmentWriter so inverted index files are
  created at the correct locations
  4. Added regression test test_insert_partial_update_with_inverted_index that verifies:
    - Partial INSERTs omitting GIN-indexed columns complete successfully
    - Existing row data is preserved correctly
    - GIN MATCH queries continue working after partial updates

  The fix ensures that inverted index files have proper paths during segment rewrite, allowing the index writer to
  initialize correctly and maintain index integrity across partial updates.
  
  ## Test Plan
````
ADMIN SET FRONTEND CONFIG ("enable_experimental_gin" = "true");
CREATE TABLE t_gin (
    pk BIGINT NOT NULL,
    v1 INT NOT NULL DEFAULT '0',
    title VARCHAR(255) NOT NULL DEFAULT '',
    INDEX gin_title (title) USING GIN ("parser" = "english")
)
PRIMARY KEY(pk)
DISTRIBUTED BY HASH(pk) BUCKETS 1
PROPERTIES ("replicated_storage" = "true", "replication_num" = "1");

insert into t_gin values (1, 100, 'hello world'), (2, 200, 'starrocks rocks');

-- partial INSERT omitting the GIN-indexed column must succeed (regression: used to hang/fail)
insert into t_gin (pk, v1) values (1, 111), (3, 300);

select pk, v1, title from t_gin order by pk;

-- GIN MATCH queries must still work after the partial update
select pk from t_gin where title match 'hello' order by pk;
select pk from t_gin where title match 'starrocks' order by pk;
````

expected output:
````
query1
1	111	hello world
2	200	starrocks rocks
3	300	

query2
1

query3
2
````

Important: this PR isn't touching lake mode, so lake mode might have the problem. I won't fix it because it's more complex