### PR TITLE
added thrift/TOutput.h include in thrift_util.cpp

### DIFF
--- a/be/src/util/thrift_util.cpp
+++ b/be/src/util/thrift_util.cpp
@@ -35,6 +35,7 @@
 #include "util/thrift_util.h"
 
 #include <thrift/Thrift.h>
+#include <thrift/TOutput.h>
 #include <thrift/concurrency/ThreadManager.h>
 #include <thrift/server/TNonblockingServer.h>
 #include <thrift/transport/TServerSocket.h>


### PR DESCRIPTION
## Why I'm doing:

/root/starrocks-pinterest-configurations/pinterest-starrocks-oss/be/src/util/thrift_util.cpp: In function ‘void starrocks::init_thrift_logging()’:
/root/starrocks-pinterest-configurations/pinterest-starrocks-oss/be/src/util/thrift_util.cpp:105:21: error: ‘GlobalOutput’ is not a member of ‘apache::thrift’
  105 |     apache::thrift::GlobalOutput.setOutputFunction(thrift_output_function);
      |                     ^~~~~~~~~~~~
/root/starrocks-pinterest-configurations/pinterest-starrocks-oss/be/src/util/thrift_util.cpp: At global scope:
/root/starrocks-pinterest-configurations/pinterest-starrocks-oss/be/src/util/thrift_util.cpp:100:13: warning: ‘void starrocks::thrift_output_function(const char*)’ defined but not used [-Wunused-function]
  100 | static void thrift_output_function(const char* output) {
      |             ^~~~~~~~~~~~~~~~~~~~~~
make[2]: *** [src/util/CMakeFiles/Util.dir/thrift_util.cpp.o] Error 1
make[1]: *** [src/util/CMakeFiles/Util.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....

## What I'm doing:

Added #include <thrift/TOutput.h> to be/src/util/thrift_util.cpp

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
