### PR TITLE
Removed the incompatible Thrift hook usage

### DIFF
--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -86,12 +86,6 @@ extern "C" {
 void __lsan_do_leak_check();
 }
 
-namespace starrocks {
-static void thrift_output(const char* x) {
-    LOG(WARNING) << "thrift internal message: " << x;
-}
-} // namespace starrocks
-
 static Aws::Utils::Logging::LogLevel parse_aws_sdk_log_level(const std::string& s) {
     Aws::Utils::Logging::LogLevel levels[] = {
             Aws::Utils::Logging::LogLevel::Off,   Aws::Utils::Logging::LogLevel::Fatal,
@@ -251,8 +245,6 @@ int main(int argc, char** argv) {
         }
     }
 
-    // Add logger for thrift internal.
-    apache::thrift::GlobalOutput.setOutputFunction(starrocks::thrift_output);
 
     // cn need to support all ops for cloudnative table, so just start_be
     starrocks::start_be(paths, as_cn);

--- a/be/src/util/thrift_util.cpp
+++ b/be/src/util/thrift_util.cpp
@@ -35,7 +35,6 @@
 #include "util/thrift_util.h"
 
 #include <thrift/Thrift.h>
-#include <thrift/TOutput.h>
 #include <thrift/concurrency/ThreadManager.h>
 #include <thrift/server/TNonblockingServer.h>
 #include <thrift/transport/TServerSocket.h>
@@ -98,12 +97,9 @@ bool TNetworkAddress::operator<(const TNetworkAddress& that) const {
     return false;
 };
 
-static void thrift_output_function(const char* output) {
-    VLOG_QUERY << output;
-}
-
 void init_thrift_logging() {
-    apache::thrift::GlobalOutput.setOutputFunction(thrift_output_function);
+    // `apache::thrift::GlobalOutput` was removed in newer Thrift versions.
+    // Keep this as a compatibility no-op when building against those versions.
 }
 
 Status wait_for_local_server(const ThriftServer& server, int num_retries, int retry_interval_ms) {


### PR DESCRIPTION
## Why I'm doing:

/root/starrocks-pinterest-configurations/pinterest-starrocks-oss/be/src/util/thrift_util.cpp: In function ‘void starrocks::init_thrift_logging()’:
/root/starrocks-pinterest-configurations/pinterest-starrocks-oss/be/src/util/thrift_util.cpp:106:21: error: ‘GlobalOutput’ is not a member of ‘apache::thrift’
  106 |     apache::thrift::GlobalOutput.setOutputFunction(thrift_output_function);
      |                     ^~~~~~~~~~~~
/root/starrocks-pinterest-configurations/pinterest-starrocks-oss/be/src/util/thrift_util.cpp: At global scope:
/root/starrocks-pinterest-configurations/pinterest-starrocks-oss/be/src/util/thrift_util.cpp:101:13: warning: ‘void starrocks::thrift_output_function(const char*)’ defined but not used [-Wunused-function]
  101 | static void thrift_output_function(const char* output) {
      |             ^~~~~~~~~~~~~~~~~~~~~~
make[2]: *** [src/util/CMakeFiles/Util.dir/thrift_util.cpp.o] Error 1
make[1]: *** [src/util/CMakeFiles/Util.dir/all] Error 2

## What I'm doing:

Updated two spots that used apache::thrift::GlobalOutput
be/src/util/thrift_util.cpp
Removed #include <thrift/TOutput.h>
Removed the now-unused thrift_output_function(...)

Made init_thrift_logging() a compatibility no-op with a short comment
be/src/service/starrocks_main.cpp
Removed the thrift_output(...) helper
Removed apache::thrift::GlobalOutput.setOutputFunction(...) in main()

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
