### PR TITLE
Add system_select_row_cap FE config for cluster-level SELECT row ceiling

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1503,6 +1503,17 @@ public class Config extends ConfigBase {
     public static int max_query_retry_time = 2;
 
     /**
+     * Platform-enforced, cluster-level ceiling on the number of rows a standalone SELECT may return.
+     * When > 0, the planner injects a LIMIT on eligible SELECTs (the same injection point as the
+     * session variable {@code sql_select_limit}) and applies the smaller of this cap and the user's
+     * {@code sql_select_limit}. Unlike the session variable, this cannot be raised or disabled by a
+     * user, since there is no session-level SET for an FE config. 0 disables the cap.
+     * INSERT ... SELECT, CTAS, UPDATE/DELETE, and MV builds are never capped.
+     */
+    @ConfField(mutable = true)
+    public static long system_select_row_cap = 0;
+
+    /**
      * In order not to wait too long for create table(index), set a max timeout.
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -39,6 +39,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableFunction;
 import com.starrocks.catalog.Type;
 import com.starrocks.catalog.View;
+import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.connector.ConnectorTableVersion;
 import com.starrocks.connector.PointerType;
@@ -194,8 +195,14 @@ public class RelationTransformer implements AstVisitor<LogicalPlan, ExpressionMa
     public LogicalPlan transformWithSelectLimit(Relation relation) {
         LogicalPlan plan = transform(relation);
         OptExprBuilder root = plan.getRootBuilder();
-        // Set limit if user set sql_select_limit.
-        long selectLimit = ConnectContext.get().getSessionVariable().getSqlSelectLimit();
+        // Apply the smaller of the user's sql_select_limit and the platform-enforced
+        // system_select_row_cap (FE config, admin-owned). The cap only tightens the limit;
+        // it never overrides an explicit LIMIT already in the query.
+        long userLimit = ConnectContext.get().getSessionVariable().getSqlSelectLimit();
+        long systemCap = Config.system_select_row_cap;
+        long selectLimit = systemCap > 0
+                ? (userLimit == SessionVariable.DEFAULT_SELECT_LIMIT ? systemCap : Math.min(userLimit, systemCap))
+                : userLimit;
         if (!root.getRoot().getOp().hasLimit() && selectLimit != SessionVariable.DEFAULT_SELECT_LIMIT) {
             LogicalLimitOperator limitOperator = LogicalLimitOperator.init(selectLimit);
             root = root.withNewRoot(limitOperator);


### PR DESCRIPTION
## Summary
- Adds a mutable, admin-owned FE config `system_select_row_cap` (default `0` = off) that caps how many rows a standalone `SELECT` may return, cluster-wide.
- Injected at the same planner point as `sql_select_limit` (`RelationTransformer.transformWithSelectLimit`); applies the **smaller** of the user's `sql_select_limit` and the cap.
- Unlike a `SET GLOBAL` session default, an FE config has **no session-level `SET`**, so users cannot raise or disable it — it is a true platform ceiling.
- Writes (`INSERT ... SELECT`, CTAS, `UPDATE`/`DELETE`, MV builds) are never capped; explicit `LIMIT`s already in the query are not overridden.

## Files
- `fe/fe-core/.../common/Config.java` — new `system_select_row_cap` field.
- `fe/fe-core/.../sql/optimizer/transformer/RelationTransformer.java` — apply `min(sql_select_limit, cap)`.

## Test plan
Validated on a dev cluster (table = 1000 rows):
- [x] cap=0 → unbounded `SELECT` returns 1000
- [x] cap=100 → unbounded `SELECT` returns 100; `EXPLAIN` shows injected `limit: 100`
- [x] explicit `LIMIT 10` → 10 (honored)
- [x] `SET sql_select_limit=50` (cap 100) → 50 (min)
- [x] `SET sql_select_limit=200` (cap 100) → 100 (user cannot exceed cap)
- [x] CTAS / `INSERT...SELECT` → all 1000 rows (writes not capped)
- [x] reset cap=0 → 1000 again
- [x] set in `fe.conf` → read at FE startup, survives restart (per-FE)
[StarRocks system_select_row_cap — feature test](https://docs.google.com/document/d/1NTpCVfZ5DPFCIy0VveMdouc1jN-Y-pyNmsaYTbmGq4E/edit?tab=t.0)

JIRA: https://pinterest.atlassian.net/browse/RTA-8647

Made with [Cursor](https://cursor.com)