### PR TITLE
Bump CN starlet to v3.5.0 to complete shared-data GetShard fix

### DIFF
--- a/docker/dockerfiles/dev-env/dev-env.Dockerfile
+++ b/docker/dockerfiles/dev-env/dev-env.Dockerfile
@@ -22,7 +22,7 @@ ARG predownload_thirdparty=false
 ARG thirdparty_url=https://cdn-thirdparty.starrocks.com/starrocks-thirdparty-main-20250731.tar
 ARG commit_id
 # check thirdparty/starlet-artifacts-version.sh, to get the right tag
-ARG starlet_tag=v3.5-rc5
+ARG starlet_tag=v4.1-rc4
 # build for which linux distro: centos7|ubuntu
 ARG distro=ubuntu
 # Token to access artifacts in private github repositories.

--- a/docker/dockerfiles/dev-env/dev-env.Dockerfile
+++ b/docker/dockerfiles/dev-env/dev-env.Dockerfile
@@ -22,7 +22,7 @@ ARG predownload_thirdparty=false
 ARG thirdparty_url=https://cdn-thirdparty.starrocks.com/starrocks-thirdparty-main-20250731.tar
 ARG commit_id
 # check thirdparty/starlet-artifacts-version.sh, to get the right tag
-ARG starlet_tag=v4.1-rc4
+ARG starlet_tag=v3.5.0
 # build for which linux distro: centos7|ubuntu
 ARG distro=ubuntu
 # Token to access artifacts in private github repositories.

--- a/thirdparty/starlet-artifacts-version.sh
+++ b/thirdparty/starlet-artifacts-version.sh
@@ -9,4 +9,4 @@
 #   https://hub.docker.com/r/starrocks/starlet-artifacts-centos7/tags
 #
 # Update the following tag when STARLET releases a new version.
-export STARLET_ARTIFACTS_TAG=v4.1-rc4
+export STARLET_ARTIFACTS_TAG=v3.5.0

--- a/thirdparty/starlet-artifacts-version.sh
+++ b/thirdparty/starlet-artifacts-version.sh
@@ -9,4 +9,4 @@
 #   https://hub.docker.com/r/starrocks/starlet-artifacts-centos7/tags
 #
 # Update the following tag when STARLET releases a new version.
-export STARLET_ARTIFACTS_TAG=v3.5-rc5
+export STARLET_ARTIFACTS_TAG=v4.1-rc4


### PR DESCRIPTION
## Summary
Completes the CN-side of the shared-data "GetShard ... Deadline Exceeded" fix (StarRocks #66429; upstream #68762 / #68756).

On `pinterest-integration-3.5` the fix was only **half** applied:

| Component | Before this PR | Has fix? |
|---|---|---|
| `staros.version` (FE jars / starmanager) | **4.1-rc4** — bumped in **PR #131** (libthrift 0.23.0 CVE cherry-pick) | ✅ yes |
| starlet tag (CN) — `starlet-artifacts-version.sh` + dev-env `starlet_tag` | **v3.5-rc5** | ❌ no |

`v3.5-rc5` predates the fix and doesn't even carry the `no_wait_replica_allocation` proto field, so the CN never requests the async replica-allocation path — the deadline storm can still take out healthy CNs.

This PR bumps the starlet tag **`v3.5-rc5` → `v3.5.0`**, which:
- carries the fix (`no_wait_replica_allocation` proto field present; `scheduleAsyncAddToGroup` in StarManager), and
- stays on the **3.5 line**, so it's API-compatible with the 3.5 BE. This is exactly upstream #68762's choice.

### Why v3.5.0 and not v4.1-rc4
My first instinct was to match the starlet tag to the already-pinned `staros.version` (`4.1-rc4`) so CN and starmanager sit on the same line. But `v4.1-rc4` starlet changed the fslib API — `FileSystem::drop_cache(string_view, int64_t offset, int64_t size)` (3 args) — while the 3.5 BE still calls the 1-arg `drop_cache(pair.first)` in `be/src/fs/fs_starlet.cpp:590`, so the BE fails to compile (*"no matching function for call to drop_cache(std::string&)"*). `v3.5.0` keeps the 1-arg signature (compiles) and still carries the fix.

`staros.version` is intentionally left at `4.1-rc4` (already correct from #131) — it carries the starmanager side of the fix, and reverting it would undo #131's CVE cherry-pick. `v3.5.0` starlet and `4.1-rc4` starmanager are protocol-compatible (both carry `no_wait_replica_allocation`). This PR only closes the remaining CN-side gap.

## Files
- `thirdparty/starlet-artifacts-version.sh` — `STARLET_ARTIFACTS_TAG` `v3.5-rc5` → `v3.5.0`
- `docker/dockerfiles/dev-env/dev-env.Dockerfile` — `ARG starlet_tag` `v3.5-rc5` → `v3.5.0`

## Test plan
- [x] Build: the `v3.5.0`-starlet tarball compiles (the `v4.1-rc4` attempt fails on the `drop_cache` API mismatch above); deployed CN BE binary contains `no_wait_replica_allocation` (`strings … | grep -c` = 1).
- [x] Proto-field check: `v3.5-rc5` `shard.proto` has 0 occurrences of `no_wait_replica_allocation`; `v3.5.0` has it + `scheduleAsyncAddToGroup` in StarManager.
- [x] CN-kill chaos A/B on dev3 (16,384-shard lake table, 16 parallel full-scan loops, `starmgr_client_rpc_timeout_ms` forced to 500 ms — 10× tighter than the 5 s default — on all 24 CNs):
  - no-fix starlet: `GetShard ... Deadline Exceeded` reproduced on survivor CNs.
  - this build (`v3.5.0` starlet): single CN hard-kill → 3,844 successful queries, **0** GetShard/Deadline errors; escalated to 3-of-24 CNs down → still **0** (only 5 transient `Backend node not found` at the kill instant, self-cleared).

[StarRocks shared-data CN-shutdown StarOS update](https://docs.google.com/document/d/1agRW1nXZDAHId8fAnSIQ9aFFHiKOPp66w5il7mrDvgU/edit?tab=t.0)

JIRA: https://pinterest.atlassian.net/browse/RTA-8647

Made with [Cursor](https://cursor.com)
